### PR TITLE
feat: prepare next Pivi release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
       "dependencies": {
         "@codemirror/state": "^6.7.1",
         "@codemirror/view": "^6.43.6",
-        "@earendil-works/pi-agent-core": "^0.80.3",
-        "@earendil-works/pi-ai": "^0.80.3",
-        "@earendil-works/pi-coding-agent": "^0.80.3",
+        "@earendil-works/pi-agent-core": "^0.80.6",
+        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-coding-agent": "^0.80.6",
         "@lobehub/icons-static-svg": "^1.91.0",
         "@modelcontextprotocol/sdk": "~1.29.0",
         "smol-toml": "^1.7.0",
@@ -26,7 +26,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/jest": "^30.0.0",
-        "@types/node": "^26.1.0",
+        "@types/node": "^26.1.1",
         "@typescript-eslint/eslint-plugin": "^8.63.0",
         "@typescript-eslint/parser": "^8.63.0",
         "esbuild": "^0.28.1",
@@ -1046,12 +1046,12 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.3.tgz",
-      "integrity": "sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ==",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
+      "integrity": "sha512-Lvn89ko42h5ETUb6Z0Ku6ldskEqXaTdQBYvSa0+7bdG9V6rUEpXptv5e0OVZ1HDcvi8s6/2lGCQWsxKX+DFHNw==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.80.6",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1061,9 +1061,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
-      "integrity": "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
+      "integrity": "sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -1086,15 +1086,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.3.tgz",
-      "integrity": "sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA==",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.80.6.tgz",
+      "integrity": "sha512-vcfD6tOk402isLl3Cm/qbn2O10TvgroMp1+/fEGM24ZdvETFCdOYv5VZ7m59EI5fPsjfSJh+CpQ5bhBrhfOg7g==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.3",
-        "@earendil-works/pi-ai": "^0.80.3",
-        "@earendil-works/pi-tui": "^0.80.3",
+        "@earendil-works/pi-agent-core": "^0.80.6",
+        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-tui": "^0.80.6",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1557,11 +1557,11 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.3.tgz",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.80.6.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-ai": "^0.80.6",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1571,8 +1571,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.3.tgz",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.80.6.tgz",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -1595,8 +1595,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.80.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
+      "version": "0.80.6",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.6.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -4735,9 +4735,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -14113,9 +14113,9 @@
     "packages/pivi-agent-core": {
       "name": "@pivi/pivi-agent-core",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.80.3",
-        "@earendil-works/pi-ai": "^0.80.3",
-        "@earendil-works/pi-coding-agent": "^0.80.3"
+        "@earendil-works/pi-agent-core": "^0.80.6",
+        "@earendil-works/pi-ai": "^0.80.6",
+        "@earendil-works/pi-coding-agent": "^0.80.6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/jest": "^30.0.0",
-    "@types/node": "^26.1.0",
+    "@types/node": "^26.1.1",
     "@typescript-eslint/eslint-plugin": "^8.63.0",
     "@typescript-eslint/parser": "^8.63.0",
     "esbuild": "^0.28.1",
@@ -56,9 +56,9 @@
   "dependencies": {
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.6",
-    "@earendil-works/pi-agent-core": "^0.80.3",
-    "@earendil-works/pi-ai": "^0.80.3",
-    "@earendil-works/pi-coding-agent": "^0.80.3",
+    "@earendil-works/pi-agent-core": "^0.80.6",
+    "@earendil-works/pi-ai": "^0.80.6",
+    "@earendil-works/pi-coding-agent": "^0.80.6",
     "@lobehub/icons-static-svg": "^1.91.0",
     "@modelcontextprotocol/sdk": "~1.29.0",
     "smol-toml": "^1.7.0",

--- a/packages/obsidian-host/src/storage/sharedStorageService.ts
+++ b/packages/obsidian-host/src/storage/sharedStorageService.ts
@@ -11,6 +11,7 @@ import {
 import { ObsidianVaultFileAdapter } from "./obsidianVaultFileAdapter";
 
 const PIVI_STORAGE_PATH = ".pivi";
+const TAB_MANAGER_STATE_PATH = `${PIVI_STORAGE_PATH}/tab-manager-state.json`;
 
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -57,23 +58,43 @@ export class SharedStorageService implements SharedAppStorage {
 
   async setTabManagerState(state: AppTabManagerState): Promise<void> {
     try {
-      const loaded: unknown = await this.plugin.loadData();
-      const data = isRecord(loaded) ? loaded : {};
-      data.tabManagerState = state;
-      await this.plugin.saveData(data);
+      await this.writeTabManagerStateFile(state);
+      await this.writeLegacyTabManagerState(state);
     } catch {
       new Notice(this.notices.failedSaveTabLayout);
     }
   }
 
+  private async writeLegacyTabManagerState(state: AppTabManagerState): Promise<void> {
+    try {
+      const loaded: unknown = await this.plugin.loadData();
+      const data = isRecord(loaded) ? loaded : {};
+      data.tabManagerState = state;
+      await this.plugin.saveData(data);
+    } catch {
+      // `.pivi` is the durable cross-device copy; legacy plugin data is best effort.
+    }
+  }
+
   async getTabManagerState(): Promise<AppTabManagerState | null> {
+    const vaultState = await this.readTabManagerStateFile();
+    if (vaultState) {
+      return vaultState;
+    }
+
     try {
       const data: unknown = await this.plugin.loadData();
       if (!isRecord(data) || !data.tabManagerState) {
         return null;
       }
 
-      return this.validateTabManagerState(data.tabManagerState);
+      const legacyState = this.validateTabManagerState(data.tabManagerState);
+      if (legacyState) {
+        await this.writeTabManagerStateFile(legacyState).catch(() => {
+          // Legacy state still restores locally even if migration fails.
+        });
+      }
+      return legacyState;
     } catch (error) {
       console.warn("Pivi: failed to load tab manager state", error);
       return null;
@@ -111,6 +132,27 @@ export class SharedStorageService implements SharedAppStorage {
   private async ensureDirectories(): Promise<void> {
     await this.adapter.ensureFolder(PIVI_STORAGE_PATH);
     await this.adapter.ensureFolder(`${PIVI_STORAGE_PATH}/sessions`);
+  }
+
+  private async writeTabManagerStateFile(state: AppTabManagerState): Promise<void> {
+    await this.adapter.write(
+      TAB_MANAGER_STATE_PATH,
+      `${JSON.stringify(state, null, 2)}\n`,
+    );
+  }
+
+  private async readTabManagerStateFile(): Promise<AppTabManagerState | null> {
+    try {
+      if (!(await this.adapter.exists(TAB_MANAGER_STATE_PATH))) {
+        return null;
+      }
+      return this.validateTabManagerState(
+        JSON.parse(await this.adapter.read(TAB_MANAGER_STATE_PATH)),
+      );
+    } catch (error) {
+      console.warn("Pivi: failed to load vault tab manager state", error);
+      return null;
+    }
   }
 
   private validateTabManagerState(data: unknown): AppTabManagerState | null {

--- a/packages/pivi-agent-core/package.json
+++ b/packages/pivi-agent-core/package.json
@@ -39,8 +39,8 @@
     "typecheck": "echo \"typecheck placeholder\""
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": "^0.80.3",
-    "@earendil-works/pi-ai": "^0.80.3",
-    "@earendil-works/pi-coding-agent": "^0.80.3"
+    "@earendil-works/pi-agent-core": "^0.80.6",
+    "@earendil-works/pi-ai": "^0.80.6",
+    "@earendil-works/pi-coding-agent": "^0.80.6"
   }
 }

--- a/packages/pivi-agent-core/src/engine/pi/piThinkingLevels.ts
+++ b/packages/pivi-agent-core/src/engine/pi/piThinkingLevels.ts
@@ -14,12 +14,16 @@ const THINKING_LEVEL_DESCRIPTIONS: Record<ThinkingLevel, string> = {
   low: 'Light reasoning (~2k tokens)',
   medium: 'Moderate reasoning (~8k tokens)',
   high: 'Deep reasoning (~16k tokens)',
-  xhigh: 'Maximum reasoning (~32k tokens)',
+  xhigh: 'Extra-high reasoning (~32k tokens)',
+  max: 'Maximum model-supported reasoning',
 };
 
 function formatThinkingLevelLabel(level: ThinkingLevel): string {
-  if (level === 'xhigh') {
+  if (level === 'max') {
     return 'Max';
+  }
+  if (level === 'xhigh') {
+    return 'XHigh';
   }
   return level.charAt(0).toUpperCase() + level.slice(1);
 }

--- a/packages/pivi-agent-core/src/engine/pi/session/piSessionStore.ts
+++ b/packages/pivi-agent-core/src/engine/pi/session/piSessionStore.ts
@@ -126,6 +126,7 @@ function sessionMetaEqual(
 ): boolean {
   return !!a
     && a.title === b.title
+    && a.titleSource === b.titleSource
     && a.createdAt === b.createdAt
     && a.titleGenerationStatus === b.titleGenerationStatus
     && a.lastResponseAt === b.lastResponseAt;
@@ -282,11 +283,22 @@ export class PiSessionStore implements SessionStore {
         if (meta?.title) {
           title = meta.title;
         }
+        const titleSource = meta?.titleSource;
         if (meta?.lastResponseAt) {
           updatedAt = meta.lastResponseAt;
         }
         leafCount = 1;
         messagePreview = firstUserMessagePreview(linearEntries);
+        summaries.push({
+          sessionFile,
+          sessionId: info.id,
+          title: title || messagePreview,
+          ...(titleSource ? { titleSource } : {}),
+          updatedAt,
+          leafCount,
+          messagePreview,
+        });
+        continue;
       } catch {
         // use SessionManager list defaults
       }
@@ -318,6 +330,7 @@ export class PiSessionStore implements SessionStore {
         hour: "2-digit",
         minute: "2-digit",
       }),
+      titleSource: 'timestamp',
       createdAt: now,
     });
     return Promise.resolve(this.refFromStore(store));
@@ -540,6 +553,7 @@ export class PiSessionStore implements SessionStore {
     const existing = readSessionMetaFromBranch(store.getEntries());
     const next: PiviSessionMetaData = {
       title: patch.title ?? existing?.title ?? "New session",
+      titleSource: patch.titleSource ?? existing?.titleSource,
       createdAt: patch.createdAt ?? existing?.createdAt ?? Date.now(),
       titleGenerationStatus:
         patch.titleGenerationStatus ?? existing?.titleGenerationStatus,

--- a/packages/pivi-agent-core/src/foundation/chat.ts
+++ b/packages/pivi-agent-core/src/foundation/chat.ts
@@ -104,6 +104,8 @@ export interface OpenSessionState {
   externalContextPaths?: string[];
   /** Context window usage information. */
   usage?: UsageInfo;
+  /** Source that last set the visible title. */
+  titleSource?: 'timestamp' | 'firstPrompt' | 'model' | 'custom';
   /** Status of AI title generation. */
   titleGenerationStatus?: 'pending' | 'success' | 'failed';
   /** UI-enabled MCP servers for this session (context-saving servers activated via selector). */
@@ -120,6 +122,8 @@ export interface SessionSummary {
   lastResponseAt?: number;
   messageCount: number;
   preview: string;
+  /** Source that last set the visible title. */
+  titleSource?: 'timestamp' | 'firstPrompt' | 'model' | 'custom';
   /** Status of AI title generation. */
   titleGenerationStatus?: 'pending' | 'success' | 'failed';
   /** Vault-relative JSONL session file. */

--- a/packages/pivi-agent-core/src/prompt/titleGeneration.ts
+++ b/packages/pivi-agent-core/src/prompt/titleGeneration.ts
@@ -7,9 +7,10 @@ export const TITLE_GENERATION_SYSTEM_PROMPT = `You are a specialist in summarizi
 
 **Rules**:
 1.  **Format**: Sentence case. No periods/quotes.
-2.  **Structure**: Start with a **strong verb** (e.g., Create, Fix, Debug, Explain, Analyze).
-3.  **Forbidden**: "Session with...", "Help me...", "Question about...", "I need...".
-4.  **Tech Context**: Detect and include the primary language/framework if code is present (e.g., "Debug Python script", "Refactor React hook").
+2.  **Language**: Use the same natural language as the user's request. If the request is in Chinese, Japanese, Korean, Spanish, etc., write the title in that language instead of English.
+3.  **Structure**: Start with a **strong verb** when it is natural in that language (e.g., Create, Fix, Debug, Explain, Analyze).
+4.  **Forbidden**: "Session with...", "Help me...", "Question about...", "I need...".
+5.  **Tech Context**: Detect and include the primary language/framework if code is present (e.g., "Debug Python script", "Refactor React hook").
 
 **Output**: Return ONLY the raw title text.`;
 

--- a/packages/pivi-agent-core/src/session/openSessionManager.ts
+++ b/packages/pivi-agent-core/src/session/openSessionManager.ts
@@ -112,6 +112,7 @@ export class OpenSessionManager {
       leafId: null,
       leafCount: 1,
       messages: [],
+      titleSource: summary.titleSource,
       titleGenerationStatus: undefined,
     }));
   }
@@ -143,6 +144,7 @@ export class OpenSessionManager {
       const ref = await store.open(openSession.sessionFile);
       await store.writeSessionMeta(ref, {
         title: openSession.title,
+        titleSource: openSession.titleSource,
         titleGenerationStatus: openSession.titleGenerationStatus,
         lastResponseAt: openSession.lastResponseAt,
         createdAt: openSession.createdAt,
@@ -232,6 +234,7 @@ export class OpenSessionManager {
       sessionId = ref.sessionId;
       await this.deps.getStore().writeSessionMeta(ref, {
         title: this.generateDefaultTitle(),
+        titleSource: 'timestamp',
         createdAt: Date.now(),
       });
     }
@@ -252,6 +255,7 @@ export class OpenSessionManager {
       leafId: null,
       leafCount: 1,
       messages: [],
+      titleSource: 'timestamp',
     };
 
     this.sessions.unshift(openSession);
@@ -295,11 +299,12 @@ export class OpenSessionManager {
     return openSession;
   }
 
-  async rename(id: string, title: string): Promise<void> {
+  async rename(id: string, title: string, titleSource?: OpenSessionState['titleSource']): Promise<void> {
     const openSession = this.getSync(id);
     if (!openSession) return;
 
     openSession.title = title.trim() || this.generateDefaultTitle();
+    openSession.titleSource = titleSource ?? openSession.titleSource;
     openSession.updatedAt = Date.now();
     await this.persistSessionSummary(openSession);
   }
@@ -348,6 +353,7 @@ export class OpenSessionManager {
       lastResponseAt: openSession.lastResponseAt,
       messageCount: openSession.messages.length,
       preview: this.getPreview(openSession),
+      titleSource: openSession.titleSource,
       titleGenerationStatus: openSession.titleGenerationStatus,
       sessionFile: openSession.sessionFile,
       leafCount: 1,

--- a/packages/pivi-agent-core/src/session/types.ts
+++ b/packages/pivi-agent-core/src/session/types.ts
@@ -5,8 +5,11 @@ export const PIVI_SESSION_META = 'pivi/session-meta';
 export const PIVI_UI_CONTEXT = 'pivi/ui-context';
 export const PIVI_MESSAGE_UI = 'pivi/message-ui';
 
+export type SessionTitleSource = 'timestamp' | 'firstPrompt' | 'model' | 'custom';
+
 export interface PiviSessionMetaData {
   title: string;
+  titleSource?: SessionTitleSource;
   titleGenerationStatus?: 'pending' | 'success' | 'failed';
   createdAt: number;
   lastResponseAt?: number;
@@ -57,6 +60,7 @@ export interface StoreSessionInfo {
   sessionFile: string;
   sessionId: string;
   title: string;
+  titleSource?: SessionTitleSource;
   updatedAt: number;
   leafCount: number;
   messagePreview: string;
@@ -70,6 +74,7 @@ export interface SessionUiContext {
 
 export interface SessionMetaPatch {
   title?: string;
+  titleSource?: SessionTitleSource;
   titleGenerationStatus?: 'pending' | 'success' | 'failed';
   lastResponseAt?: number;
   createdAt?: number;

--- a/src/app/hostContracts.ts
+++ b/src/app/hostContracts.ts
@@ -207,7 +207,11 @@ export interface PiviChatHost extends PiviHostCore {
   ): Promise<OpenSessionState | null>;
   deleteSession(id: string): Promise<void>;
   purgeDeletedSessionFiles(): Promise<number>;
-  renameSession(id: string, title: string): Promise<void>;
+  renameSession(
+    id: string,
+    title: string,
+    titleSource?: OpenSessionState['titleSource'],
+  ): Promise<void>;
   updateSession(id: string, updates: Partial<OpenSessionState>): Promise<void>;
   listSessionLeaves(sessionFile: string): Promise<LeafSummary[]>;
   forkSessionAt(

--- a/src/app/pluginSessionApi.ts
+++ b/src/app/pluginSessionApi.ts
@@ -147,8 +147,9 @@ export async function renameSession(
   ctx: PluginSessionContext,
   id: string,
   title: string,
+  titleSource?: OpenSessionState['titleSource'],
 ): Promise<void> {
-  await ctx.sessionManager.rename(id, title);
+  await ctx.sessionManager.rename(id, title, titleSource);
 }
 
 export async function updateSession(

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -109,12 +109,15 @@
       "startNewChat": "Neuen Chat starten",
       "archiveTab": "{title} archivieren",
       "restoreTab": "{title} wiederherstellen",
+      "editTitle": "Titel für {title} bearbeiten",
+      "editTitleInputLabel": "Tabtitel",
       "closeTab": "{title} schließen",
       "archived": "Archiviert",
       "failedCreateChat": "Chat konnte nicht erstellt werden",
       "failedCreateTab": "Tab konnte nicht erstellt werden",
       "failedSwitchTab": "Tab konnte nicht gewechselt werden",
       "failedCloseTab": "Tab konnte nicht geschlossen werden",
+      "failedEditTitle": "Tabtitel konnte nicht bearbeitet werden",
       "failedArchiveTab": "Tab konnte nicht archiviert werden"
     },
     "errors": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -109,12 +109,15 @@
       "startNewChat": "Start new chat",
       "archiveTab": "Archive {title}",
       "restoreTab": "Restore {title}",
+      "editTitle": "Edit title for {title}",
+      "editTitleInputLabel": "Tab title",
       "closeTab": "Close {title}",
       "archived": "Archived",
       "failedCreateChat": "Failed to create chat",
       "failedCreateTab": "Failed to create tab",
       "failedSwitchTab": "Failed to switch tab",
       "failedCloseTab": "Failed to close tab",
+      "failedEditTitle": "Failed to edit tab title",
       "failedArchiveTab": "Failed to archive tab"
     },
     "errors": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -109,12 +109,15 @@
       "startNewChat": "Iniciar chat nuevo",
       "archiveTab": "Archivar {title}",
       "restoreTab": "Restaurar {title}",
+      "editTitle": "Editar título de {title}",
+      "editTitleInputLabel": "Título de pestaña",
       "closeTab": "Cerrar {title}",
       "archived": "Archivado",
       "failedCreateChat": "Error al crear el chat",
       "failedCreateTab": "Error al crear la pestaña",
       "failedSwitchTab": "Error al cambiar de pestaña",
       "failedCloseTab": "Error al cerrar la pestaña",
+      "failedEditTitle": "Error al editar el título de la pestaña",
       "failedArchiveTab": "Error al archivar la pestaña"
     },
     "errors": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -109,12 +109,15 @@
       "startNewChat": "Démarrer un nouveau chat",
       "archiveTab": "Archiver {title}",
       "restoreTab": "Restaurer {title}",
+      "editTitle": "Modifier le titre de {title}",
+      "editTitleInputLabel": "Titre de l’onglet",
       "closeTab": "Fermer {title}",
       "archived": "Archivé",
       "failedCreateChat": "Échec de la création du chat",
       "failedCreateTab": "Échec de la création de l’onglet",
       "failedSwitchTab": "Échec du changement d’onglet",
       "failedCloseTab": "Échec de la fermeture de l’onglet",
+      "failedEditTitle": "Échec de la modification du titre de l’onglet",
       "failedArchiveTab": "Échec de l’archivage de l’onglet"
     },
     "errors": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -109,12 +109,15 @@
       "startNewChat": "新しいチャットを開始",
       "archiveTab": "{title} をアーカイブ",
       "restoreTab": "{title} を復元",
+      "editTitle": "{title} のタイトルを編集",
+      "editTitleInputLabel": "タブタイトル",
       "closeTab": "{title} を閉じる",
       "archived": "アーカイブ済み",
       "failedCreateChat": "チャットの作成に失敗しました",
       "failedCreateTab": "タブの作成に失敗しました",
       "failedSwitchTab": "タブの切り替えに失敗しました",
       "failedCloseTab": "タブを閉じられませんでした",
+      "failedEditTitle": "タブタイトルの編集に失敗しました",
       "failedArchiveTab": "タブのアーカイブに失敗しました"
     },
     "errors": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -109,12 +109,15 @@
       "startNewChat": "새 채팅 시작",
       "archiveTab": "{title} 보관",
       "restoreTab": "{title} 복원",
+      "editTitle": "{title} 제목 편집",
+      "editTitleInputLabel": "탭 제목",
       "closeTab": "{title} 닫기",
       "archived": "보관됨",
       "failedCreateChat": "채팅을 만들지 못했습니다",
       "failedCreateTab": "탭을 만들지 못했습니다",
       "failedSwitchTab": "탭을 전환하지 못했습니다",
       "failedCloseTab": "탭을 닫지 못했습니다",
+      "failedEditTitle": "탭 제목을 편집하지 못했습니다",
       "failedArchiveTab": "탭을 보관하지 못했습니다"
     },
     "errors": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -109,12 +109,15 @@
       "startNewChat": "Iniciar novo chat",
       "archiveTab": "Arquivar {title}",
       "restoreTab": "Restaurar {title}",
+      "editTitle": "Editar título de {title}",
+      "editTitleInputLabel": "Título da aba",
       "closeTab": "Fechar {title}",
       "archived": "Arquivados",
       "failedCreateChat": "Falha ao criar o chat",
       "failedCreateTab": "Falha ao criar a aba",
       "failedSwitchTab": "Falha ao alternar a aba",
       "failedCloseTab": "Falha ao fechar a aba",
+      "failedEditTitle": "Falha ao editar o título da aba",
       "failedArchiveTab": "Falha ao arquivar a aba"
     },
     "errors": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -109,12 +109,15 @@
       "startNewChat": "Начать новый чат",
       "archiveTab": "Архивировать {title}",
       "restoreTab": "Восстановить {title}",
+      "editTitle": "Изменить заголовок {title}",
+      "editTitleInputLabel": "Заголовок вкладки",
       "closeTab": "Закрыть {title}",
       "archived": "В архиве",
       "failedCreateChat": "Не удалось создать чат",
       "failedCreateTab": "Не удалось создать вкладку",
       "failedSwitchTab": "Не удалось переключить вкладку",
       "failedCloseTab": "Не удалось закрыть вкладку",
+      "failedEditTitle": "Не удалось изменить заголовок вкладки",
       "failedArchiveTab": "Не удалось архивировать вкладку"
     },
     "errors": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -109,12 +109,15 @@
       "startNewChat": "开始新聊天",
       "archiveTab": "归档 {title}",
       "restoreTab": "恢复 {title}",
+      "editTitle": "编辑 {title} 的标题",
+      "editTitleInputLabel": "标签页标题",
       "closeTab": "关闭 {title}",
       "archived": "已归档",
       "failedCreateChat": "创建聊天失败",
       "failedCreateTab": "创建标签页失败",
       "failedSwitchTab": "切换标签页失败",
       "failedCloseTab": "关闭标签页失败",
+      "failedEditTitle": "编辑标签页标题失败",
       "failedArchiveTab": "归档标签页失败"
     },
     "errors": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -109,12 +109,15 @@
       "startNewChat": "開始新聊天",
       "archiveTab": "封存 {title}",
       "restoreTab": "還原 {title}",
+      "editTitle": "編輯 {title} 的標題",
+      "editTitleInputLabel": "分頁標題",
       "closeTab": "關閉 {title}",
       "archived": "已封存",
       "failedCreateChat": "建立聊天失敗",
       "failedCreateTab": "建立分頁失敗",
       "failedSwitchTab": "切換分頁失敗",
       "failedCloseTab": "關閉分頁失敗",
+      "failedEditTitle": "編輯分頁標題失敗",
       "failedArchiveTab": "封存分頁失敗"
     },
     "errors": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -354,8 +354,12 @@ export default class PiviPlugin extends Plugin implements PiviPluginHost {
     return sessionApi.purgeDeletedSessionFiles(this.sessionContext());
   }
 
-  async renameSession(id: string, title: string): Promise<void> {
-    await sessionApi.renameSession(this.sessionContext(), id, title);
+  async renameSession(
+    id: string,
+    title: string,
+    titleSource?: OpenSessionState['titleSource'],
+  ): Promise<void> {
+    await sessionApi.renameSession(this.sessionContext(), id, title, titleSource);
   }
 
   async updateSession(

--- a/src/styles/accessibility.css
+++ b/src/styles/accessibility.css
@@ -8,10 +8,19 @@
 .pivi-model-btn:focus-visible,
 .pivi-thinking-current:focus-visible,
 .pivi-tab-switcher-trigger:focus-visible,
-.pivi-tab-switcher-new-chat:focus-visible {
+.pivi-tab-switcher-new-chat:focus-visible,
+.pivi-tab-switcher-action:focus-visible {
   outline: 2px solid var(--interactive-accent);
   outline-offset: 2px;
   border-radius: 4px;
+}
+
+.pivi-tab-switcher-item:focus-visible {
+  outline: none;
+  background: var(--background-modifier-hover);
+  box-shadow:
+    inset 0 0 0 1px var(--background-modifier-border-hover),
+    inset 0 0 18px rgba(var(--mono-rgb-100), 0.10);
 }
 
 /* outline + offset only */

--- a/src/styles/components/tabs.css
+++ b/src/styles/components/tabs.css
@@ -105,10 +105,18 @@
 }
 
 .pivi-tab-switcher-item-title {
+  display: flex;
+  align-items: center;
   min-width: 0;
+  height: 1.2em;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-family: var(--font-interface);
+  font-size: var(--font-ui-small);
+  font-weight: inherit;
+  line-height: 1.2;
+  letter-spacing: inherit;
 }
 
 .pivi-tab-switcher-dot {
@@ -227,7 +235,8 @@
 
 .pivi-tab-switcher-item {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+  grid-template-columns: auto minmax(0, 1fr);
+  position: relative;
   align-items: center;
   gap: 8px;
   min-height: 28px;
@@ -246,6 +255,56 @@
   overflow: hidden;
   transform-origin: top;
   will-change: opacity, transform;
+}
+
+/* Continuous action mask: fully solid under the three icons, long soft fade
+   left into the title (gradient may be long; icons must never show title). */
+.pivi-tab-switcher-item::after {
+  content: "";
+  position: absolute;
+  z-index: 1;
+  inset-block: 0;
+  inset-inline-end: 0;
+  /* 66px solid icon zone + ~40px fade into title */
+  width: 106px;
+  opacity: 0;
+  pointer-events: none;
+  /* Left: long fade over title. Right from ~38%: fully opaque under icons. */
+  background: linear-gradient(
+    to right,
+    transparent 0%,
+    color-mix(in srgb, var(--background-primary) 22%, transparent) 14%,
+    color-mix(in srgb, var(--background-primary) 48%, transparent) 24%,
+    color-mix(in srgb, var(--background-primary) 78%, transparent) 32%,
+    var(--background-primary) 38%,
+    var(--background-primary) 100%
+  );
+  transition: opacity 0.14s ease;
+}
+
+.pivi-tab-switcher-item:hover::after,
+.pivi-tab-switcher-item:focus-within::after {
+  opacity: 1;
+  /* Opaque primary base + hover tint; solid from 38% onward covers all icons. */
+  background:
+    linear-gradient(
+      to right,
+      transparent 0%,
+      color-mix(in srgb, var(--background-modifier-hover) 22%, transparent) 14%,
+      color-mix(in srgb, var(--background-modifier-hover) 48%, transparent) 24%,
+      color-mix(in srgb, var(--background-modifier-hover) 78%, transparent) 32%,
+      var(--background-modifier-hover) 38%,
+      var(--background-modifier-hover) 100%
+    ),
+    linear-gradient(
+      to right,
+      transparent 0%,
+      color-mix(in srgb, var(--background-primary) 22%, transparent) 14%,
+      color-mix(in srgb, var(--background-primary) 48%, transparent) 24%,
+      color-mix(in srgb, var(--background-primary) 78%, transparent) 32%,
+      var(--background-primary) 38%,
+      var(--background-primary) 100%
+    );
 }
 
 .pivi-tab-switcher-item.is-exiting {
@@ -280,34 +339,94 @@
   background: var(--background-modifier-hover);
 }
 
-.pivi-tab-switcher-archive,
-.pivi-tab-switcher-close {
-  display: flex;
-  color: var(--text-faint);
+.pivi-tab-switcher-title-input {
+  appearance: none;
+  -webkit-appearance: none;
+  box-sizing: border-box;
+  flex: 1 1 auto;
+  display: block;
+  width: 100%;
+  min-width: 0;
+  height: 1.2em !important;
+  min-height: 0 !important;
+  max-height: 1.2em !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  color: inherit !important;
+  /* Force same face as title text; Obsidian theme inputs often use a different font. */
+  font-family: var(--font-interface) !important;
+  font-size: var(--font-ui-small) !important;
+  font-weight: inherit !important;
+  font-style: inherit !important;
+  letter-spacing: inherit !important;
+  line-height: 1.2 !important;
+  background: transparent !important;
+  vertical-align: middle;
 }
 
+.pivi-tab-switcher-title-input:focus,
+.pivi-tab-switcher-title-input:focus-visible {
+  border: 0 !important;
+  box-shadow: none !important;
+  outline: none !important;
+  background: transparent !important;
+}
+
+.pivi-tab-switcher-action {
+  position: absolute;
+  z-index: 2;
+  top: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  transform: translateY(-50%);
+  color: var(--text-normal);
+  background: transparent;
+  pointer-events: none;
+  visibility: hidden;
+  border-radius: 5px;
+  transition: color 0.12s ease, background 0.12s ease;
+}
+
+.pivi-tab-switcher-edit-title {
+  inset-inline-end: 48px;
+}
+
+.pivi-tab-switcher-archive {
+  inset-inline-end: 27px;
+}
+
+.pivi-tab-switcher-close {
+  inset-inline-end: 6px;
+}
+
+.pivi-tab-switcher-edit-title svg,
 .pivi-tab-switcher-archive svg,
 .pivi-tab-switcher-close svg {
   width: 14px;
   height: 14px;
 }
 
-.pivi-tab-switcher-archive,
-.pivi-tab-switcher-close {
-  opacity: 0;
-  border-radius: 5px;
-  transition: opacity 0.12s ease, color 0.12s ease, background 0.12s ease;
-}
-
+.pivi-tab-switcher-item:hover .pivi-tab-switcher-edit-title,
 .pivi-tab-switcher-item:hover .pivi-tab-switcher-archive,
-.pivi-tab-switcher-item:hover .pivi-tab-switcher-close {
-  opacity: 1;
+.pivi-tab-switcher-item:hover .pivi-tab-switcher-close,
+.pivi-tab-switcher-item:focus-within .pivi-tab-switcher-edit-title,
+.pivi-tab-switcher-item:focus-within .pivi-tab-switcher-archive,
+.pivi-tab-switcher-item:focus-within .pivi-tab-switcher-close {
+  pointer-events: auto;
+  visibility: visible;
 }
 
+.pivi-tab-switcher-edit-title:hover,
 .pivi-tab-switcher-archive:hover,
 .pivi-tab-switcher-close:hover {
   color: var(--text-normal);
-  background: var(--background-modifier-border);
+  background: var(--background-modifier-border-hover);
 }
 
 @keyframes pivi-tab-menu-in {

--- a/src/ui/chat/controllers/TitleGenerationCoordinator.ts
+++ b/src/ui/chat/controllers/TitleGenerationCoordinator.ts
@@ -54,9 +54,14 @@ export class TitleGenerationCoordinator {
 
     const userContent = resolveUserMessageDisplayText(firstUserMsg);
 
+    const currentSession = await plugin.getOpenSessionById(state.currentOpenSessionId);
+    if (currentSession?.titleSource === 'custom') {
+      return;
+    }
+
     // Set immediate fallback title
     const fallbackTitle = openSessionController.generateFallbackTitle(userContent);
-    await plugin.renameSession(state.currentOpenSessionId, fallbackTitle);
+    await plugin.renameSession(state.currentOpenSessionId, fallbackTitle, 'firstPrompt');
 
     if (!plugin.settings.enableAutoTitleGeneration) {
       return;
@@ -83,11 +88,12 @@ export class TitleGenerationCoordinator {
         const currentConv = await plugin.getOpenSessionById(openSessionId);
         if (!currentConv) return;
 
-        // Only apply AI title if user hasn't manually renamed (title still matches fallback)
-        const userManuallyRenamed = currentConv.title !== expectedTitle;
+        // Only apply AI title if user hasn't manually renamed.
+        const userManuallyRenamed = currentConv.titleSource === 'custom'
+          || currentConv.title !== expectedTitle;
 
         if (result.success && !userManuallyRenamed) {
-          await plugin.renameSession(openSessionId, result.title);
+          await plugin.renameSession(openSessionId, result.title, 'model');
           await plugin.updateSession(openSessionId, { titleGenerationStatus: 'success' });
         } else if (!userManuallyRenamed) {
           // Keep fallback title, mark as failed (only if user hasn't renamed)

--- a/src/ui/chat/rendering/messageRendererMarkdown.ts
+++ b/src/ui/chat/rendering/messageRendererMarkdown.ts
@@ -173,7 +173,7 @@ function enhanceMermaidDiagram(container: HTMLElement): void {
   });
   makeButton('', t('chat.mermaid.fitToWidth'), () => {
     setScale(getFitToWidthScale());
-  }, 'maximize-2');
+  }, 'stretch-horizontal');
 
   scroll.addEventListener('wheel', (event) => {
     const wantsZoom = event.ctrlKey || event.metaKey;

--- a/src/ui/chat/tabs/TabBar.ts
+++ b/src/ui/chat/tabs/TabBar.ts
@@ -20,6 +20,9 @@ export interface TabBarCallbacks {
   /** Called when the archive button is clicked on a tab. */
   onTabArchive: (tabId: TabId) => void;
 
+  /** Called when the tab title is edited inline. */
+  onTabRenameTitle: (tabId: TabId, title: string) => void | Promise<void>;
+
   /** Called when the close button is clicked on a tab. */
   onTabClose: (tabId: TabId) => void;
 
@@ -41,6 +44,7 @@ export class TabBar {
   private exitTimeouts = new Map<TabId, number>();
   private lastRenderedActiveId: TabId | null = null;
   private lastRenderedActiveIndex: number | null = null;
+  private editingTabId: TabId | null = null;
 
   constructor(containerEl: HTMLElement, callbacks: TabBarCallbacks) {
     this.containerEl = containerEl;
@@ -132,17 +136,29 @@ export class TabBar {
       const chevronEl = triggerEl.createSpan({ cls: 'pivi-tab-switcher-chevron' });
       setIcon(chevronEl, 'chevron-up');
 
-      const toggle = (event: MouseEvent | KeyboardEvent): void => {
+      const toggle = (event: MouseEvent | KeyboardEvent, options?: { focusMenu?: boolean }): void => {
         event.stopPropagation();
         this.isOpen = !this.isOpen;
         this.render();
+        if (this.isOpen && options?.focusMenu) {
+          this.focusActiveMenuItem();
+        }
       };
 
       triggerEl.addEventListener('click', toggle);
       triggerEl.addEventListener('keydown', (event: KeyboardEvent) => {
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault();
-          toggle(event);
+          toggle(event, { focusMenu: true });
+        }
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+          event.preventDefault();
+          event.stopPropagation();
+          if (!this.isOpen) {
+            this.isOpen = true;
+            this.render();
+          }
+          this.focusActiveMenuItem();
         }
         if (event.key === 'Escape' && this.isOpen) {
           event.preventDefault();
@@ -195,6 +211,28 @@ export class TabBar {
 
     this.lastRenderedActiveId = activeItem.id;
     this.lastRenderedActiveIndex = activeItem.index;
+  }
+
+  private focusActiveMenuItem(): void {
+    const menuEl = this.containerEl.querySelector<HTMLElement>('.pivi-tab-switcher-menu');
+    const itemEls = Array.from(menuEl?.querySelectorAll<HTMLElement>('.pivi-tab-switcher-item') ?? []);
+    const activeItem = this.items.find(item => item.isActive);
+    const activeItemEl = activeItem
+      ? itemEls.find(el => el.getAttribute('data-tab-id') === activeItem.id)
+      : null;
+    (activeItemEl ?? itemEls[0])?.focus();
+  }
+
+  private focusAdjacentMenuItem(tabId: TabId, direction: 1 | -1): void {
+    const menuEl = this.containerEl.querySelector<HTMLElement>('.pivi-tab-switcher-menu');
+    const itemEls = Array.from(menuEl?.querySelectorAll<HTMLElement>('.pivi-tab-switcher-item') ?? []);
+    if (itemEls.length === 0) return;
+
+    const currentIndex = itemEls.findIndex(el => el.getAttribute('data-tab-id') === tabId);
+    const nextIndex = currentIndex >= 0
+      ? (currentIndex + direction + itemEls.length) % itemEls.length
+      : direction > 0 ? 0 : itemEls.length - 1;
+    itemEls[nextIndex]?.focus();
   }
 
   private getTitleScrollClass(activeItem: TabBarItem): string {
@@ -297,7 +335,30 @@ export class TabBar {
       });
       itemEl.createSpan({ cls: 'pivi-tab-switcher-item-title' });
 
-      const archiveEl = itemEl.createSpan({ cls: 'pivi-tab-switcher-archive' });
+      const beginTitleEdit = (): void => {
+        const currentItem = this.items.find(it => it.id === item.id);
+        if (!currentItem || itemEl.classList.contains('is-exiting')) return;
+
+        this.editingTabId = currentItem.id;
+        this.render();
+      };
+
+      const editTitleEl = itemEl.createSpan({ cls: 'pivi-tab-switcher-action pivi-tab-switcher-edit-title' });
+      editTitleEl.setAttribute('role', 'button');
+      editTitleEl.setAttribute('tabindex', '0');
+      editTitleEl.addEventListener('click', (event) => {
+        event.stopPropagation();
+        beginTitleEdit();
+      });
+      editTitleEl.addEventListener('keydown', (event) => {
+        event.stopPropagation();
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          beginTitleEdit();
+        }
+      });
+
+      const archiveEl = itemEl.createSpan({ cls: 'pivi-tab-switcher-action pivi-tab-switcher-archive' });
       archiveEl.setAttribute('role', 'button');
       archiveEl.addEventListener('click', (event) => {
         event.stopPropagation();
@@ -345,6 +406,10 @@ export class TabBar {
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault();
           select(event);
+        } else if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+          event.preventDefault();
+          event.stopPropagation();
+          this.focusAdjacentMenuItem(item.id, event.key === 'ArrowDown' ? 1 : -1);
         }
       });
     }
@@ -355,10 +420,18 @@ export class TabBar {
       dotEl.className = `pivi-tab-switcher-dot ${this.getDotClass(item)}`;
     }
 
-    // Update Title
     const titleEl = itemEl.querySelector('.pivi-tab-switcher-item-title') as HTMLElement;
     if (titleEl) {
-      titleEl.textContent = item.title;
+      this.renderMenuItemTitle(titleEl, item);
+    }
+
+    const editTitleEl = itemEl.querySelector('.pivi-tab-switcher-edit-title') as HTMLElement;
+    if (editTitleEl) {
+      editTitleEl.empty();
+      setIcon(editTitleEl, 'pencil');
+      const editTitleLabel = t('chat.tabs.editTitle', { title: item.title });
+      editTitleEl.setAttribute('aria-label', editTitleLabel);
+      setTabTooltip(editTitleEl, editTitleLabel);
     }
 
     // Update Archive Button
@@ -377,7 +450,7 @@ export class TabBar {
     let closeEl = itemEl.querySelector('.pivi-tab-switcher-close') as HTMLElement;
     if (item.canClose) {
       if (!closeEl) {
-        closeEl = itemEl.createSpan({ cls: 'pivi-tab-switcher-close' });
+        closeEl = itemEl.createSpan({ cls: 'pivi-tab-switcher-action pivi-tab-switcher-close' });
         setIcon(closeEl, 'x');
         closeEl.setAttribute('role', 'button');
         closeEl.addEventListener('click', (event) => {
@@ -412,6 +485,56 @@ export class TabBar {
     } else if (closeEl) {
       closeEl.remove();
     }
+  }
+
+  private renderMenuItemTitle(titleEl: HTMLElement, item: TabBarItem): void {
+    if (this.editingTabId !== item.id) {
+      titleEl.textContent = item.title;
+      return;
+    }
+
+    titleEl.empty();
+    const inputEl = titleEl.createEl('input', {
+      attr: {
+        'aria-label': t('chat.tabs.editTitleInputLabel'),
+        type: 'text',
+      },
+      cls: 'pivi-tab-switcher-title-input',
+    });
+    inputEl.value = item.title;
+
+    let submitted = false;
+    const cancel = (): void => {
+      if (submitted) return;
+      this.editingTabId = null;
+      this.render();
+    };
+    const submit = (): void => {
+      if (submitted) return;
+      submitted = true;
+      const title = inputEl.value.trim();
+      this.editingTabId = null;
+      if (title && title !== item.title) {
+        void Promise.resolve(this.callbacks.onTabRenameTitle(item.id, title)).finally(() => this.render());
+        return;
+      }
+      this.render();
+    };
+
+    inputEl.addEventListener('click', event => event.stopPropagation());
+    inputEl.addEventListener('keydown', (event) => {
+      event.stopPropagation();
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        submit();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        cancel();
+      }
+    });
+    inputEl.addEventListener('blur', submit);
+    inputEl.focus();
+    inputEl.select();
   }
 
   private getDotClass(item: TabBarItem): string {

--- a/src/ui/chat/tabs/TabManager.ts
+++ b/src/ui/chat/tabs/TabManager.ts
@@ -345,6 +345,26 @@ export class TabManager implements TabManagerInterface {
     }
   }
 
+  async renameTabTitle(tabId: TabId, title: string): Promise<void> {
+    const tab = this.tabs.get(tabId);
+    if (!tab) return;
+
+    let openSessionId = tab.openSessionId;
+    if (!openSessionId) {
+      const openSession = await this.plugin.createOpenSession();
+      openSessionId = openSession.id;
+      tab.openSessionId = openSession.id;
+      tab.state.currentOpenSessionId = openSession.id;
+      tab.sessionFile = openSession.sessionFile ?? null;
+      tab.leafId = openSession.leafId ?? null;
+      tab.lifecycleState = 'bound_cold';
+      this.callbacks.onTabSessionChanged?.(tab.id, openSession.id);
+    }
+
+    await this.plugin.renameSession(openSessionId, title, 'custom');
+    this.callbacks.onTabTitleChanged?.(tab.id, title);
+  }
+
 
   private getFallbackTabForRemoval(tabId: TabId): TabData | null {
     const orderedTabs = Array.from(this.tabs.values());

--- a/src/ui/chat/view/PiviView.ts
+++ b/src/ui/chat/view/PiviView.ts
@@ -262,6 +262,9 @@ export class PiviView extends ItemView {
       onTabArchive: (tabId) => {
         void this.handleTabArchive(tabId);
       },
+      onTabRenameTitle: (tabId, title) => {
+        void this.handleTabRenameTitle(tabId, title);
+      },
       onTabClose: (tabId) => {
         void this.handleTabClose(tabId);
       },
@@ -360,6 +363,16 @@ export class PiviView extends ItemView {
       this.updateTabBarVisibility();
     } catch {
       new Notice(t('chat.tabs.failedArchiveTab'));
+    }
+  }
+
+  private async handleTabRenameTitle(tabId: TabId, title: string): Promise<void> {
+    try {
+      await this.tabManager?.renameTabTitle(tabId, title);
+      this.updateTabBar();
+      this.persistTabState();
+    } catch {
+      new Notice(t('chat.tabs.failedEditTitle'));
     }
   }
 

--- a/tests/__mocks__/@earendil-works/pi-ai.ts
+++ b/tests/__mocks__/@earendil-works/pi-ai.ts
@@ -176,7 +176,7 @@ export function builtinModels(): any {
   };
 }
 
-const EXTENDED_THINKING_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const;
+const EXTENDED_THINKING_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
 
 export function getSupportedThinkingLevels(model: {
   reasoning?: boolean;
@@ -190,7 +190,7 @@ export function getSupportedThinkingLevels(model: {
     if (mapped === null) {
       return false;
     }
-    if (level === 'xhigh') {
+    if (level === 'xhigh' || level === 'max') {
       return mapped !== undefined;
     }
     return true;

--- a/tests/unit/app/sharedStorageService.test.ts
+++ b/tests/unit/app/sharedStorageService.test.ts
@@ -1,0 +1,74 @@
+import { SharedStorageService } from '@pivi/obsidian-host/storage/sharedStorageService';
+
+function createMemoryAdapter() {
+  const files = new Map<string, string>();
+  const folders = new Set<string>();
+  return {
+    files,
+    adapter: {
+      exists: jest.fn(async (path: string) => files.has(path) || folders.has(path)),
+      mkdir: jest.fn(async (path: string) => { folders.add(path); }),
+      read: jest.fn(async (path: string) => files.get(path) ?? ''),
+      write: jest.fn(async (path: string, content: string) => { files.set(path, content); }),
+    },
+  };
+}
+
+function createPlugin() {
+  const { adapter, files } = createMemoryAdapter();
+  return {
+    files,
+    plugin: {
+      app: { vault: { adapter } },
+      loadData: jest.fn().mockResolvedValue({}),
+      saveData: jest.fn().mockResolvedValue(undefined),
+    },
+  };
+}
+
+describe('SharedStorageService tab manager state', () => {
+  it('writes tab manager state to .pivi for vault sync', async () => {
+    const { plugin, files } = createPlugin();
+    const storage = new SharedStorageService(plugin as never);
+    const state = {
+      activeTabId: 'tab-1',
+      openTabs: [{ tabId: 'tab-1', sessionFile: '.pivi/sessions/a.jsonl' }],
+    };
+
+    await storage.setTabManagerState(state);
+
+    expect(JSON.parse(files.get('.pivi/tab-manager-state.json') ?? '')).toEqual(state);
+    expect(plugin.saveData).toHaveBeenCalledWith({ tabManagerState: state });
+  });
+
+  it('prefers .pivi tab manager state over legacy plugin data', async () => {
+    const { plugin, files } = createPlugin();
+    const storage = new SharedStorageService(plugin as never);
+    const vaultState = {
+      activeTabId: 'vault-tab',
+      openTabs: [{ tabId: 'vault-tab', sessionFile: '.pivi/sessions/vault.jsonl' }],
+    };
+    plugin.loadData.mockResolvedValue({
+      tabManagerState: {
+        activeTabId: 'legacy-tab',
+        openTabs: [{ tabId: 'legacy-tab' }],
+      },
+    });
+    files.set('.pivi/tab-manager-state.json', JSON.stringify(vaultState));
+
+    await expect(storage.getTabManagerState()).resolves.toEqual(vaultState);
+  });
+
+  it('migrates legacy plugin tab manager state into .pivi when vault state is missing', async () => {
+    const { plugin, files } = createPlugin();
+    const storage = new SharedStorageService(plugin as never);
+    const legacyState = {
+      activeTabId: 'legacy-tab',
+      openTabs: [{ tabId: 'legacy-tab', isArchived: true }],
+    };
+    plugin.loadData.mockResolvedValue({ tabManagerState: legacyState });
+
+    await expect(storage.getTabManagerState()).resolves.toEqual(legacyState);
+    expect(JSON.parse(files.get('.pivi/tab-manager-state.json') ?? '')).toEqual(legacyState);
+  });
+});

--- a/tests/unit/engine/pi/piThinkingLevels.test.ts
+++ b/tests/unit/engine/pi/piThinkingLevels.test.ts
@@ -48,6 +48,25 @@ describe('PiThinkingLevels (core)', () => {
         .find((option) => option.value === 'high');
       expect(highOption?.description).toBe('Deep reasoning (~16k tokens)');
     });
+
+    it('keeps upstream thinking-level order and labels model-specific maximum levels', () => {
+      const options = getPiThinkingLevelOptionsForModel({
+        ...reasoningFixture(),
+        thinkingLevelMap: { xhigh: 'xhigh', max: 'max' },
+      });
+
+      expect(options.map((option) => option.value)).toEqual([
+        'off',
+        'minimal',
+        'low',
+        'medium',
+        'high',
+        'xhigh',
+        'max',
+      ]);
+      expect(options.find((option) => option.value === 'xhigh')?.label).toBe('XHigh');
+      expect(options.find((option) => option.value === 'max')?.label).toBe('Max');
+    });
   });
 
   describe('isPiAdaptiveReasoningModelValue', () => {

--- a/tests/unit/features/chat/tabManagerLifecycle.test.ts
+++ b/tests/unit/features/chat/tabManagerLifecycle.test.ts
@@ -90,6 +90,7 @@ function makeManager(callbacks?: TabManagerCallbacks) {
     forkSessionAt: jest.fn(async () => ({ sessionFile: 'fork.jsonl', sessionId: 'fork-session', leafId: 'fork-leaf' })),
     getPiWorkspace: jest.fn(() => null),
     createOpenSession: jest.fn(async () => ({ id: 'fork-open' })),
+    renameSession: jest.fn(async () => {}),
     updateSession: jest.fn(async () => {}),
     deleteSession: jest.fn(async () => {}),
   });
@@ -232,6 +233,38 @@ describe('TabManager lifecycle guards', () => {
       { id: 'open', archived: false },
       { id: 'unread', archived: true },
     ]);
+  });
+
+  it('renames an existing session title as a custom title', async () => {
+    const { manager, plugin } = makeManager();
+    await manager.createTab('session-a', 'tab-a');
+
+    await manager.renameTabTitle('tab-a', 'Custom title');
+
+    expect(plugin.renameSession).toHaveBeenCalledWith('session-a', 'Custom title', 'custom');
+  });
+
+  it('creates and binds a session before renaming a blank tab title', async () => {
+    const { manager, plugin } = makeManager();
+    plugin.createOpenSession.mockResolvedValueOnce({
+      id: 'created-open',
+      sessionFile: 'created.jsonl',
+      messages: [],
+      title: 'Created',
+    } as never);
+    await manager.createTab(null, 'blank');
+
+    await manager.renameTabTitle('blank', 'Custom blank title');
+
+    expect(plugin.createOpenSession).toHaveBeenCalled();
+    expect(plugin.renameSession).toHaveBeenCalledWith('created-open', 'Custom blank title', 'custom');
+    expect(manager.getTab('blank')?.openSessionId).toBe('created-open');
+    expect(manager.getTab('blank')?.state.currentOpenSessionId).toBe('created-open');
+    expect(manager.getTab('blank')?.sessionFile).toBe('created.jsonl');
+    expect(manager.getPersistedState().openTabs).toContainEqual({
+      tabId: 'blank',
+      sessionFile: 'created.jsonl',
+    });
   });
 
   it('restores archived tabs below open tabs and reopens them when selected', async () => {

--- a/tests/unit/features/chat/titleGenerationCoordinator.test.ts
+++ b/tests/unit/features/chat/titleGenerationCoordinator.test.ts
@@ -57,7 +57,7 @@ describe('TitleGenerationCoordinator', () => {
   it('sets fallback title on first user message', async () => {
     await coordinator.triggerTitleGeneration();
     expect(mockSessionController.generateFallbackTitle).toHaveBeenCalledWith('Hello agent!');
-    expect(mockPlugin.renameSession).toHaveBeenCalledWith('session-123', 'Fallback Title');
+    expect(mockPlugin.renameSession).toHaveBeenCalledWith('session-123', 'Fallback Title', 'firstPrompt');
   });
 
   it('triggers AI title generation and renames session on success', async () => {
@@ -66,8 +66,24 @@ describe('TitleGenerationCoordinator', () => {
     await Promise.resolve();
 
     expect(mockTitleService.generateTitle).toHaveBeenCalled();
-    expect(mockPlugin.renameSession).toHaveBeenLastCalledWith('session-123', 'AI Generated Title');
+    expect(mockPlugin.renameSession).toHaveBeenLastCalledWith('session-123', 'AI Generated Title', 'model');
     expect(mockPlugin.updateSession).toHaveBeenCalledWith('session-123', { titleGenerationStatus: 'success' });
+  });
+
+  it('does not overwrite a custom title with generated title', async () => {
+    mockPlugin.getOpenSessionById.mockResolvedValue({
+      id: 'session-123',
+      title: 'Custom title',
+      titleSource: 'custom',
+    } as never);
+
+    await coordinator.triggerTitleGeneration();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockPlugin.renameSession).not.toHaveBeenCalled();
+    expect(mockTitleService.generateTitle).not.toHaveBeenCalled();
+    expect(mockPlugin.updateSession).not.toHaveBeenCalled();
   });
 
   it('does not trigger title generation if message length is not 1', async () => {

--- a/tests/unit/pi/runtime/queryBackedTitleGenerationService.test.ts
+++ b/tests/unit/pi/runtime/queryBackedTitleGenerationService.test.ts
@@ -34,6 +34,27 @@ describe('QueryBackedTitleGenerationService', () => {
     expect(runner.reset).toHaveBeenCalledTimes(1);
   });
 
+  it('instructs the model to keep the generated title in the user request language', async () => {
+    const runner = createRunner('整理会议记录');
+    const callback = jest.fn(async () => {});
+    const service = new QueryBackedTitleGenerationService({
+      createRunner: () => runner,
+    });
+
+    await service.generateTitle('session-1', '帮我整理会议记录', callback);
+
+    expect(runner.query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        systemPrompt: expect.stringContaining('Use the same natural language as the user\'s request'),
+      }),
+      expect.stringContaining('帮我整理会议记录'),
+    );
+    expect(callback).toHaveBeenCalledWith('session-1', {
+      success: true,
+      title: '整理会议记录',
+    });
+  });
+
   it('aborts and resets an in-flight generation when a newer one starts for the same session', async () => {
     let releaseFirst!: () => void;
     const firstRunner: AuxQueryRunner & { query: jest.Mock; reset: jest.Mock } = {

--- a/tests/unit/ui/chat/tabs/TabBar.test.ts
+++ b/tests/unit/ui/chat/tabs/TabBar.test.ts
@@ -7,6 +7,9 @@ class MockElement {
   attributes = new Map<string, string>();
   children: MockElement[] = [];
   textContent?: string;
+  value = '';
+  focused = false;
+  selected = false;
   parent: MockElement | null = null;
   ownerDocument = {
     defaultView: globalThis,
@@ -78,6 +81,23 @@ class MockElement {
     this.children.push(el);
     return el;
   }
+  createEl(_tag: string, options?: { cls?: string; text?: string; attr?: Record<string, string> }) {
+    const el = new MockElement();
+    el.parent = this;
+    if (options?.cls) {
+      options.cls.split(' ').filter(Boolean).forEach(c => el.addClass(c));
+    }
+    if (options?.text) {
+      el.textContent = options.text;
+    }
+    if (options?.attr) {
+      for (const [name, value] of Object.entries(options.attr)) {
+        el.setAttribute(name, value);
+      }
+    }
+    this.children.push(el);
+    return el;
+  }
   appendChild(child: MockElement) {
     if (child.parent) {
       child.parent.children = child.parent.children.filter(c => c !== child);
@@ -122,6 +142,13 @@ class MockElement {
       child.parent = null;
     }
     this.children = [];
+    this.textContent = undefined;
+  }
+  focus() {
+    this.focused = true;
+  }
+  select() {
+    this.selected = true;
   }
   remove() {
     if (this.parent) {
@@ -143,6 +170,7 @@ describe('TabBar UI Component', () => {
   let callbacks: {
     onTabClick: jest.Mock;
     onTabArchive: jest.Mock;
+    onTabRenameTitle: jest.Mock;
     onTabClose: jest.Mock;
     onStartNewChat: jest.Mock;
   };
@@ -154,6 +182,7 @@ describe('TabBar UI Component', () => {
     callbacks = {
       onTabClick: jest.fn(),
       onTabArchive: jest.fn(),
+      onTabRenameTitle: jest.fn(),
       onTabClose: jest.fn(),
       onStartNewChat: jest.fn(),
     };
@@ -272,6 +301,137 @@ describe('TabBar UI Component', () => {
     const keydownListenersCountAfter = tab2El?.listeners['keydown']?.length ?? 0;
     expect(clickListenersCountAfter).toBe(1);
     expect(keydownListenersCountAfter).toBe(1);
+  });
+
+  it('edits a title inline without selecting the tab', async () => {
+    const tabBar = new TabBar(containerEl as any, callbacks);
+    tabBar.update(items);
+
+    const controlEl = containerEl.querySelector('.pivi-tab-switcher-control');
+    const triggerEl = controlEl.querySelector('.pivi-tab-switcher-trigger');
+    triggerEl.trigger('click');
+
+    const menuEl = containerEl.querySelector('.pivi-tab-switcher-menu');
+    const tab2El = (menuEl.children as MockElement[]).find((child: MockElement) =>
+      child.classes.has('pivi-tab-switcher-item') &&
+      child.children.some((c: MockElement) => c.textContent === 'Tab 2')
+    );
+    const editTitleEl = (tab2El?.children as MockElement[]).find((child: MockElement) => child.classes.has('pivi-tab-switcher-edit-title'));
+
+    editTitleEl?.trigger('click');
+
+    const titleEl = tab2El?.querySelector('.pivi-tab-switcher-item-title');
+    const inputEl = titleEl?.querySelector('.pivi-tab-switcher-title-input');
+    expect(inputEl).toBeDefined();
+    expect(inputEl?.value).toBe('Tab 2');
+    expect(inputEl?.focused).toBe(true);
+    expect(inputEl?.selected).toBe(true);
+
+    if (inputEl) {
+      inputEl.value = 'Custom title';
+      inputEl.trigger('keydown', { key: 'Enter', stopPropagation: jest.fn(), preventDefault: jest.fn() });
+    }
+
+    await Promise.resolve();
+
+    expect(callbacks.onTabRenameTitle).toHaveBeenCalledWith('tab2', 'Custom title');
+    expect(callbacks.onTabClick).not.toHaveBeenCalled();
+  });
+
+  it('starts inline title editing from the keyboard without selecting the tab', () => {
+    const tabBar = new TabBar(containerEl as any, callbacks);
+    tabBar.update(items);
+
+    const controlEl = containerEl.querySelector('.pivi-tab-switcher-control');
+    const triggerEl = controlEl.querySelector('.pivi-tab-switcher-trigger');
+    triggerEl.trigger('click');
+
+    const menuEl = containerEl.querySelector('.pivi-tab-switcher-menu');
+    const tab2El = (menuEl.children as MockElement[]).find((child: MockElement) =>
+      child.classes.has('pivi-tab-switcher-item') &&
+      child.children.some((c: MockElement) => c.textContent === 'Tab 2')
+    );
+    const editTitleEl = (tab2El?.children as MockElement[]).find((child: MockElement) => child.classes.has('pivi-tab-switcher-edit-title'));
+    const preventDefault = jest.fn();
+
+    expect(editTitleEl?.getAttribute('tabindex')).toBe('0');
+    editTitleEl?.trigger('keydown', { key: 'Enter', stopPropagation: jest.fn(), preventDefault });
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(tab2El?.querySelector('.pivi-tab-switcher-title-input')).toBeDefined();
+    expect(callbacks.onTabClick).not.toHaveBeenCalled();
+  });
+
+  it('moves focus to the active menu item when opened from the keyboard', () => {
+    const tabBar = new TabBar(containerEl as any, callbacks);
+    tabBar.update([
+      { ...items[0], isActive: false },
+      { ...items[1], isActive: true },
+    ]);
+
+    const controlEl = containerEl.querySelector('.pivi-tab-switcher-control');
+    const triggerEl = controlEl.querySelector('.pivi-tab-switcher-trigger');
+    triggerEl.trigger('keydown', { key: 'Enter', stopPropagation: jest.fn(), preventDefault: jest.fn() });
+
+    const menuEl = containerEl.querySelector('.pivi-tab-switcher-menu');
+    const itemEls = menuEl.querySelectorAll('.pivi-tab-switcher-item');
+    expect(itemEls[1]?.focused).toBe(true);
+  });
+
+  it('moves focus from the trigger to the active menu item with arrow keys', () => {
+    const tabBar = new TabBar(containerEl as any, callbacks);
+    tabBar.update([
+      { ...items[0], isActive: false },
+      { ...items[1], isActive: true },
+    ]);
+
+    const controlEl = containerEl.querySelector('.pivi-tab-switcher-control');
+    const triggerEl = controlEl.querySelector('.pivi-tab-switcher-trigger');
+    triggerEl.trigger('click');
+    triggerEl.trigger('keydown', { key: 'ArrowDown', stopPropagation: jest.fn(), preventDefault: jest.fn() });
+
+    const menuEl = containerEl.querySelector('.pivi-tab-switcher-menu');
+    const itemEls = menuEl.querySelectorAll('.pivi-tab-switcher-item');
+    expect(itemEls[1]?.focused).toBe(true);
+  });
+
+  it('moves focus between menu items with arrow keys', () => {
+    const tabBar = new TabBar(containerEl as any, callbacks);
+    tabBar.update(items);
+
+    const controlEl = containerEl.querySelector('.pivi-tab-switcher-control');
+    const triggerEl = controlEl.querySelector('.pivi-tab-switcher-trigger');
+    triggerEl.trigger('keydown', { key: 'Enter', stopPropagation: jest.fn(), preventDefault: jest.fn() });
+
+    const menuEl = containerEl.querySelector('.pivi-tab-switcher-menu');
+    const itemEls = menuEl.querySelectorAll('.pivi-tab-switcher-item');
+    itemEls[0]?.trigger('keydown', { key: 'ArrowDown', stopPropagation: jest.fn(), preventDefault: jest.fn() });
+
+    expect(itemEls[1]?.focused).toBe(true);
+  });
+
+  it('cancels inline title editing on Escape', () => {
+    const tabBar = new TabBar(containerEl as any, callbacks);
+    tabBar.update(items);
+
+    const controlEl = containerEl.querySelector('.pivi-tab-switcher-control');
+    const triggerEl = controlEl.querySelector('.pivi-tab-switcher-trigger');
+    triggerEl.trigger('click');
+
+    const menuEl = containerEl.querySelector('.pivi-tab-switcher-menu');
+    const tab2El = (menuEl.children as MockElement[]).find((child: MockElement) =>
+      child.classes.has('pivi-tab-switcher-item') &&
+      child.children.some((c: MockElement) => c.textContent === 'Tab 2')
+    );
+    const editTitleEl = (tab2El?.children as MockElement[]).find((child: MockElement) => child.classes.has('pivi-tab-switcher-edit-title'));
+
+    editTitleEl?.trigger('click');
+
+    const inputEl = tab2El?.querySelector('.pivi-tab-switcher-title-input');
+    inputEl?.trigger('keydown', { key: 'Escape', stopPropagation: jest.fn(), preventDefault: jest.fn() });
+
+    expect(callbacks.onTabRenameTitle).not.toHaveBeenCalled();
+    expect(callbacks.onTabClick).not.toHaveBeenCalled();
   });
 
   it('switches active tab immediately to a fallback tab when closing the active tab', () => {


### PR DESCRIPTION
## Description

Prepares the next release with two user-facing features:

- Adds editable synced chat tab titles, including custom-title protection from automatic title generation and vault-synced tab layout state.
- Adds support for the max Pi thinking level.
- Improves tab switcher keyboard focus and Mermaid fit-to-width icon clarity.

## Related issue

Fixes #36

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Related guidance

- Package: packages/pivi-agent-core/AGENTS.md
- Package: packages/obsidian-host/AGENTS.md
- Local: src/app/AGENTS.md
- Local: src/i18n/AGENTS.md
- Tests: tests/AGENTS.md

## Checklist

- [x] npm run typecheck passes
- [x] npm run lint passes
- [x] npm run check:architecture passes
- [x] Focused tests pass
- [x] npm run build passes
- [x] Tested in Obsidian
- [ ] manifest.json / versions.json updated if releasing

## Testing environment

- Obsidian: local app via obsidian CLI
- OS: macOS

## Verification

Ran:

```bash
npm run test -- --runInBand tests/unit/pi/runtime/queryBackedTitleGenerationService.test.ts tests/unit/features/chat/tabAgentContext.test.ts tests/unit/ui/chat/tabs/TabBar.test.ts tests/unit/features/chat/titleGenerationCoordinator.test.ts tests/unit/features/chat/tabManagerLifecycle.test.ts tests/unit/app/sharedStorageService.test.ts
npm run typecheck
npm run lint -- --quiet
npm run check:architecture
npm run build
obsidian reload
obsidian dev:errors
```

Manual checks performed:

- Custom tab titles persist and are not overwritten by fallback/model-generated titles.
- Tab switcher keyboard focus starts at the active tab and moves with arrow keys.
- Focus styling uses a darker in-row shadow instead of an external outline.
- Title generation prompt now instructs the model to keep the title language aligned with the user's request.

## Release note

After this PR merges to main, Release Please should open/update the release PR for the next pre-1.0 minor release. No direct release metadata bump is included here.
