### PR TITLE
chore(deps): upgrade react and react-dom to 19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ plans/
 # Git Worktrees
 .worktrees/
 
+# Agent skills (local development tooling)
+.agents/skills/
+

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -110,6 +110,7 @@ export default defineConfig([
       "main.js",
       "metafile.json",
       "styles.css",
+      ".agents/skills/**",
     ],
   },
   ...obsidianmd.configs.recommended,

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,8 @@
         "@lobehub/icons-static-svg": "^1.93.0",
         "@modelcontextprotocol/sdk": "~1.29.0",
         "@tanstack/react-virtual": "^3.14.7",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "tslib": "^2.8.1"
       },
       "devDependencies": {
@@ -33,8 +33,8 @@
         "@testing-library/react": "^16.3.2",
         "@types/jest": "^30.0.0",
         "@types/node": "^26.1.1",
-        "@types/react": "^18.3.31",
-        "@types/react-dom": "^18.3.7",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
         "@typescript-eslint/eslint-plugin": "^8.65.0",
         "@typescript-eslint/parser": "^8.65.0",
         "esbuild": "^0.28.1",
@@ -5094,32 +5094,24 @@
         "undici-types": "~8.3.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/retry": {
@@ -11559,6 +11551,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -11854,6 +11847,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -12901,28 +12895,24 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-is": {
@@ -13239,13 +13229,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -15221,8 +15208,8 @@
         "@tanstack/react-virtual": "^3.14.7"
       },
       "peerDependencies": {
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "@testing-library/react": "^16.3.2",
     "@types/jest": "^30.0.0",
     "@types/node": "^26.1.1",
-    "@types/react": "^18.3.31",
-    "@types/react-dom": "^18.3.7",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.65.0",
     "@typescript-eslint/parser": "^8.65.0",
     "esbuild": "^0.28.1",
@@ -76,8 +76,8 @@
     "@lobehub/icons-static-svg": "^1.93.0",
     "@modelcontextprotocol/sdk": "~1.29.0",
     "@tanstack/react-virtual": "^3.14.7",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "tslib": "^2.8.1"
   },
   "overrides": {

--- a/packages/pivi-react/package.json
+++ b/packages/pivi-react/package.json
@@ -16,7 +16,7 @@
     "@tanstack/react-virtual": "^3.14.7"
   },
   "peerDependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   }
 }

--- a/packages/pivi-react/src/reorder/useSortableReorder.ts
+++ b/packages/pivi-react/src/reorder/useSortableReorder.ts
@@ -49,7 +49,7 @@ interface UseSortableReorderOptions<ItemId extends string> {
 }
 
 interface SortableReorder<ItemId extends string, Element extends HTMLElement> {
-  readonly listRef: RefObject<HTMLDivElement>;
+  readonly listRef: RefObject<HTMLDivElement | null>;
   readonly draggingId: ItemId | null;
   readonly dragOffset: number;
   readonly announcement: string;


### PR DESCRIPTION
## Summary

Combines Dependabot PRs #58 (react + @types/react) and #59 (react-dom + @types/react-dom) into a single upgrade. These two PRs must land together: upgrading only ReactDOM 19 against React 18 runtime causes widespread test failures from version mismatch, and upgrading only React 19 leaves ReactDOM at 18.

## Changes

- **`package.json`**: bump `react`/`react-dom` to `^19.2.7`, `@types/react` to `^19.2.17`, `@types/react-dom` to `^19.2.3` (matches both Dependabot PR versions)
- **`packages/pivi-react/package.json`**: sync peer deps from `^18.3.1` to `^19.0.0`
- **`packages/pivi-react/src/reorder/useSortableReorder.ts`**: update `RefObject<HTMLDivElement>` to `RefObject<HTMLDivElement | null>` — the single type error from React 19 stricter ref nullability (`useRef<HTMLDivElement>(null)` now returns `RefObject<HTMLDivElement | null>`)
- **`.gitignore` / `eslint.config.mjs`**: ignore `.agents/skills/` so local agent skill reference files do not break lint or the pre-commit hook

## Verification

- [x] `npm run typecheck` (source + tests)
- [x] `npm run lint` (zero warnings/errors)
- [x] `npm run check:boundaries` (architecture, package readmes, i18n dead keys, specs)
- [x] `npm run test` — 2107 tests passed, 271 suites
- [x] `npm run build` — main.js 3.06 MB (1.94 MB below 5 MB cap)
- [x] `npm run check:bundle-size`
- [x] Obsidian live reload + `pivi:open-view` — no new errors

## Notes

No source refactoring needed: the codebase already uses `createRoot` (not `ReactDOM.render`), has no `forwardRef`, `React.FC`, `MutableRefObject`, `defaultProps`, global `JSX` namespace augmentation, or argument-less `useRef()`. The only breaking type change was the `RefObject` nullability.

Closes #58, closes #59.

Related guidance:
- Package: packages/pivi-react/AGENTS.md
