### PR TITLE
docs: add community contribution paths

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,74 @@
+name: Bug report
+description: Report a reproducible problem with Pivi
+title: "[Bug]: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. For usage questions, use Discussions Q&A. Do not post vulnerabilities or secrets here; use the private Security Advisory link in the issue chooser.
+  - type: input
+    id: pivi-version
+    attributes:
+      label: Pivi version
+      description: Find this in Community Plugins or manifest.json.
+      placeholder: 0.25.0
+    validations:
+      required: true
+  - type: input
+    id: obsidian-version
+    attributes:
+      label: Obsidian version
+      placeholder: 1.13.0
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - iOS (not supported)
+        - Android (not supported)
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Use a minimal test vault when possible and remove private vault content and credentials.
+      placeholder: |
+        1. Open …
+        2. Run …
+        3. Observe …
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result and logs
+      description: Include relevant errors or screenshots after removing secrets and personal note content.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Relevant provider/model, enabled integration, theme, or conflicting plugin.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues and Discussions.
+          required: true
+        - label: This report contains no secrets or undisclosed security vulnerability.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Usage questions
+    url: https://github.com/shuuul/obsidian-pivi/discussions/categories/q-a
+    about: Ask for setup and workflow help in Discussions Q&A.
+  - name: Ideas and early proposals
+    url: https://github.com/shuuul/obsidian-pivi/discussions/categories/ideas
+    about: Discuss an idea before turning it into focused repository work.
+  - name: Report a security vulnerability
+    url: https://github.com/shuuul/obsidian-pivi/security/advisories/new
+    about: Privately report vulnerabilities; do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: Feature request
+description: Propose a focused improvement to Pivi
+title: "[Feature]: "
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: For open-ended workflow discussion, start in Discussions Ideas. Do not post security concerns here.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: Describe the knowledge-work problem, not only a proposed control.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Explain the smallest useful outcome and how it fits an Obsidian workflow.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Relevant platform
+      options:
+        - All desktop platforms
+        - macOS
+        - Windows
+        - Linux
+        - Not platform-specific
+    validations:
+      required: true
+  - type: input
+    id: versions
+    attributes:
+      label: Pivi and Obsidian versions
+      placeholder: Pivi 0.25.0; Obsidian 1.13.0
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues and Discussions.
+          required: true
+        - label: This request contains no secrets or undisclosed security vulnerability.
+          required: true

--- a/.github/MONTHLY_MAINTENANCE_REPORT_TEMPLATE.md
+++ b/.github/MONTHLY_MAINTENANCE_REPORT_TEMPLATE.md
@@ -1,0 +1,30 @@
+# Monthly maintenance and support report — YYYY-MM
+
+Post in **Discussions → Announcements**. Report only verifiable repository activity; do not expose reporter or security-advisory details.
+
+## Maintenance
+
+- Releases and dependency/security maintenance
+- CI or platform evidence changed
+- Documentation or recipe changes
+
+## Support
+
+- Themes seen in public Q&A and bug reports
+- Resolved or still-open support gaps
+
+## Platform status
+
+- macOS:
+- Windows preview:
+- Linux preview:
+
+## Funding
+
+- Sponsor destination: Not configured / link
+- Funds received and project expenses, if any: Not reported / summary
+
+## Next month
+
+- Maintenance priorities
+- Contributions or testing needed

--- a/.github/WEEKLY_UPDATE_TEMPLATE.md
+++ b/.github/WEEKLY_UPDATE_TEMPLATE.md
@@ -1,0 +1,19 @@
+# Weekly update — YYYY-MM-DD
+
+Post in **Discussions → Announcements**.
+
+## Shipped
+
+- User-visible change with link
+
+## In progress
+
+- Focused work and current status
+
+## Needs input
+
+- Question, issue, or test request with link
+
+## Next
+
+- One or two priorities for the coming week

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# Code of Conduct
+
+## Our pledge
+
+We pledge to make participation in the Pivi community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, experience, education, socioeconomic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Expected behavior
+
+- Be empathetic and respectful of differing viewpoints and experiences.
+- Give and accept constructive feedback gracefully.
+- Focus on what is best for the community and take responsibility for mistakes.
+- Do not harass, insult, threaten, sexualize, or publish another person's private information.
+
+## Scope
+
+This code applies in repository issues, pull requests, Discussions, and other spaces where someone officially represents Pivi.
+
+## Enforcement
+
+Project maintainers may edit, remove, or reject contributions and may temporarily or permanently restrict participation for behavior they deem inappropriate, threatening, offensive, or harmful.
+
+Report abusive content privately with GitHub's **Report content** control on the relevant comment or account. GitHub sends that report to repository maintainers or GitHub Support without requiring you to publish personal contact details. If immediate safety is at risk, contact the appropriate local authority. Do not use public issues for conduct reports.
+
+Maintainers will respect the privacy and security of reporters. Enforcement decisions may include a private warning, removal of content, a temporary restriction, or a permanent ban, based on impact and recurrence.
+
+## Attribution
+
+This code is a concise adaptation of the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to Pivi
+
+Thanks for helping improve Pivi. By participating, you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Set up
+
+Pivi requires Node.js 24.x. Fork and clone the repository, then run:
+
+```bash
+npm ci
+npm run build
+```
+
+For live testing, set `OBSIDIAN_VAULT` in `.env.local`, build, enable Pivi once, and reload it with `obsidian plugin:reload id=pivi`. See the [development handbook](docs/09-development-debugging-and-validation.md) for the complete workflow.
+
+## Choose and discuss work
+
+- Ask usage and design questions in [Discussions](https://github.com/shuuul/obsidian-pivi/discussions).
+- Use the bug or feature issue form for actionable repository work. Search existing issues first.
+- For a larger change, wait for scope agreement before investing in an implementation.
+- Never disclose a vulnerability publicly; follow [SECURITY.md](SECURITY.md).
+
+## Make a focused change
+
+Read the root and nearest nested `AGENTS.md`, the [architecture overview](docs/02-architecture-and-technology.md), and the handbook page that owns the behavior. Preserve package dependency direction and add focused behavior tests. Update the relevant numbered handbook page and nearest `AGENTS.md` when architecture, behavior, or an enforceable boundary changes.
+
+Use a short branch and keep the pull request to one concern. Do not include release/version changes unless the change is specifically a release preparation.
+
+## Validate
+
+Run the narrowest relevant test while iterating, for example:
+
+```bash
+npm run test -- tests/unit/path/to/test.ts
+```
+
+Before opening a pull request, run the checks relevant to the files changed. The complete CI-equivalent suite is:
+
+```bash
+npm run check:dependencies
+npm run typecheck
+npm run lint
+npm run check:boundaries
+npm run test:coverage
+npm run build
+npm run check:bundle-size
+```
+
+UI or runtime changes also need testing in Obsidian. Record the Obsidian version, Pivi version, and operating system. Rendered CSS changes require human visual review in a reloaded Obsidian window.
+
+## Open a pull request
+
+Complete the pull request template, link the issue, describe user-visible and architectural effects, and list exact validation performed. Add screenshots for visual changes. Review feedback may request a smaller scope or documentation/test updates before merge.

--- a/README.md
+++ b/README.md
@@ -211,12 +211,13 @@ On first launch with no vault skills installed, Pivi asks before installing [kep
 ## Requirements
 
 - **Obsidian** v1.13.0+ (desktop only)
-- **macOS** (tested; Windows / Linux should work but not officially supported)
+- **Platforms:** macOS Supported; Windows and Linux Preview; iOS and Android Not supported. See the [support matrix](docs/platform-support.md) for current CI and smoke-test scope.
 
 ---
 
 ## Documentation
 
+- [Recipes](docs/recipes/README.md) — review-first prompts for literature triage, weekly review, and vault cleanup
 - [Developer handbook](docs/README.md) — architecture, technology choices, feature flows, and contribution routes
 - [Input panel and context](docs/04-input-panel-and-context.md) — composer, selectors, context indicators, and prompt construction
 - [Tabs, sessions, and history](docs/05-tabs-sessions-and-history.md) — tab switcher, persistence, restore, and fork
@@ -248,6 +249,12 @@ Full trust-boundary, disclosure, credential matrix, network, prompt-injection, a
 
 </details>
 
+## Community
+
+- [Contribute](CONTRIBUTING.md) — development setup, validation, and pull request flow
+- [Discussions](https://github.com/shuuul/obsidian-pivi/discussions) — questions and ideas
+- [Show and tell](https://github.com/shuuul/obsidian-pivi/discussions/categories/show-and-tell) — share recipes and vault workflows
+- [Support](SUPPORT.md) — choose the right route for help, bugs, features, or security reports
 
 
 ## Acknowledgments

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,11 @@
+# Pivi support
+
+Choose the route that matches the request:
+
+- **Usage and setup questions:** ask in [Discussions Q&A](https://github.com/shuuul/obsidian-pivi/discussions/categories/q-a). Include Pivi, Obsidian, and operating-system versions.
+- **Ideas and workflow examples:** use [Discussions](https://github.com/shuuul/obsidian-pivi/discussions). Share working setups in [Show and tell](https://github.com/shuuul/obsidian-pivi/discussions/categories/show-and-tell).
+- **Reproducible bugs:** use the [bug report form](https://github.com/shuuul/obsidian-pivi/issues/new?template=bug_report.yml).
+- **Feature requests:** use the [feature request form](https://github.com/shuuul/obsidian-pivi/issues/new?template=feature_request.yml).
+- **Security vulnerabilities:** report privately through [GitHub Security Advisories](https://github.com/shuuul/obsidian-pivi/security/advisories/new), as described in [SECURITY.md](SECURITY.md). Never include secrets or unfixed vulnerability details in a public issue.
+
+Support is community-maintained and response times are not guaranteed. Check the [platform support matrix](docs/platform-support.md) before reporting a platform-specific problem.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,8 @@ For long-running or multi-agent work, use the tracked [specs system](../specs/RE
 | [10 — Roadmap, release, and maintenance](10-roadmap-release-and-maintenance.md) | Reviewing current technical priorities, publishing, or maintaining docs |
 | [11 — Chat UI evolution](11-chat-ui-evolution.md) | Planning long-session architecture, Agent activity, context memory, and the future visual language |
 
+User-facing references: [recipes](recipes/README.md), [platform support](platform-support.md), [support routes](../SUPPORT.md), and [contribution guide](../CONTRIBUTING.md).
+
 ## Overall architecture
 
 Pivi is an Obsidian desktop plugin with one agent runtime: Pi. `src/main.ts` is the composition root. Application code constructs host services and the concrete engine, product UI orchestrates chat behavior through injected contracts, React owns product presentation, and reusable packages enforce host and runtime boundaries.

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -1,0 +1,13 @@
+# Platform support
+
+Pivi is a desktop-only Obsidian plugin. The tiers below describe current project testing and maintenance, not a guarantee that every feature works on every machine.
+
+| Platform | Tier | Evidence and scope |
+|---|---|---|
+| macOS | Supported | Primary development platform; focused path, process, MCP, and Skills security tests run in CI. The real Obsidian lifecycle smoke is available and requires a maintainer's configured macOS vault. |
+| Windows | Preview | Focused path, process, MCP, and Skills security tests run in CI. Full product and real-Obsidian smoke coverage are not continuous. |
+| Linux | Preview | The full quality-gate suite runs on Ubuntu CI. Full product and real-Obsidian smoke coverage are not continuous. |
+| iOS | Not supported | `manifest.json` declares `isDesktopOnly`; desktop process and integration capabilities are required. |
+| Android | Not supported | `manifest.json` declares `isDesktopOnly`; desktop process and integration capabilities are required. |
+
+Preview-platform bug reports are welcome when they include exact Pivi and Obsidian versions and minimal reproduction steps. See [support routes](../SUPPORT.md).

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -1,0 +1,9 @@
+# Pivi recipes
+
+These small, review-first workflows are starting points. Adapt paths, properties, and output formats to your vault.
+
+- [Literature triage](literature-triage.md) — turn an inbox of reading notes into a reviewed shortlist.
+- [Weekly review](weekly-review.md) — summarize recent work and prepare next actions.
+- [Vault cleanup](vault-cleanup.md) — inventory likely cleanup candidates without destructive automation.
+
+Share useful adaptations in [Discussions → Show and tell](https://github.com/shuuul/obsidian-pivi/discussions/categories/show-and-tell).

--- a/docs/recipes/literature-triage.md
+++ b/docs/recipes/literature-triage.md
@@ -1,0 +1,25 @@
+# Literature triage
+
+## Use case
+
+Prioritize new reading notes in `Literature/Inbox` and identify what deserves deeper processing.
+
+## Copyable prompt
+
+```text
+Review notes in Literature/Inbox. For each note, extract its central claim, evidence type, and relevance to my current projects using links and tags already in the vault. Do not edit files. Return a table with note link, one-sentence summary, relevance (high/medium/low), reason, and one suggested next action. Flag missing source metadata instead of inventing it.
+```
+
+## Safety note
+
+Start read-only. The model can misread sources or infer relevance incorrectly; do not treat its summary as a substitute for reading. Remove sensitive text before using a hosted model.
+
+## Expected result
+
+A linked triage table, missing-metadata flags, and a small high-priority reading queue.
+
+## Review steps
+
+1. Open each high-priority source and verify the claim and evidence.
+2. Check that every link names an existing note and no citation was invented.
+3. Adjust priorities, then explicitly request any property or file edits in a separate turn.

--- a/docs/recipes/vault-cleanup.md
+++ b/docs/recipes/vault-cleanup.md
@@ -1,0 +1,26 @@
+# Vault cleanup
+
+## Use case
+
+Find likely stale, orphaned, duplicate, or poorly linked notes before a manual cleanup session.
+
+## Copyable prompt
+
+```text
+Audit the vault without editing, moving, or deleting anything. Identify: orphan notes, unresolved links, empty notes, likely duplicate titles, and notes with no modification in the last year that also have no incoming links. Return separate tables with note links, the evidence for each flag, and a conservative suggested action. Exclude .pivi and .obsidian folders. Do not call delete, move, write, or edit tools.
+```
+
+## Safety note
+
+Old or unlinked does not mean useless, and duplicate titles may be intentional. Keep File Recovery enabled and back up or version the vault before any bulk change. Never approve bulk deletion from this audit alone.
+
+## Expected result
+
+A non-destructive inventory grouped by cleanup signal, with evidence and suggested review actions.
+
+## Review steps
+
+1. Sample every category and correct false positives.
+2. Open candidates and inspect backlinks, embeds, aliases, and external references.
+3. Resolve links or merge notes in small batches.
+4. Move deletions to trash only after a final human review; rerun the audit afterward.

--- a/docs/recipes/weekly-review.md
+++ b/docs/recipes/weekly-review.md
@@ -1,0 +1,26 @@
+# Weekly review
+
+## Use case
+
+Turn recent daily notes and open tasks into a concise weekly review and next-week plan.
+
+## Copyable prompt
+
+```text
+Read my daily notes from the last seven days and list open tasks referenced there. Do not change task status or write files. Draft a weekly review with: completed outcomes, unresolved items, recurring themes, blocked work, and at most five next actions. Link each claim to the supporting note. Mark uncertainty when the notes are ambiguous.
+```
+
+## Safety note
+
+Keep the first pass read-only. Hosted providers may receive selected vault context. Pivi may miss work recorded outside the requested notes, and an unchecked task is not always unfinished.
+
+## Expected result
+
+A source-linked review draft and a short proposed action list ready to paste into a weekly note.
+
+## Review steps
+
+1. Verify completion and blocker claims against the linked notes.
+2. Add work that happened outside the vault and remove stale tasks.
+3. Reorder the proposed actions yourself.
+4. Ask Pivi to write the approved draft only after choosing the destination note.

--- a/specs/049-post-review-contracts-architecture-and-community-execution.md
+++ b/specs/049-post-review-contracts-architecture-and-community-execution.md
@@ -21,9 +21,9 @@ The broader review's repository popularity and download figures were externally 
 
 Preserve Pivi's existing package architecture while making active documentation mechanically truthful, reducing composition and public-API friction in bounded slices, and establishing visible contribution, support, compatibility, and maintenance loops.
 
-- [ ] P0 issue #100 is merged with one machine-readable v0.25.0 capability contract, aligned active docs, a focused regression suite, and the docs check in shared quality gates.
-- [ ] No post-P0 workstream starts until GitHub reports the issue #100 pull request as merged; the merge URL and commit are recorded in Progress and handoff.
-- [ ] Repository rules protect `main` and SemVer release tags without requiring a second reviewer while Pivi remains single-maintainer.
+- [x] P0 issue #100 is merged with one machine-readable v0.25.0 capability contract, aligned active docs, a focused regression suite, and the docs check in shared quality gates.
+- [x] No post-P0 workstream starts until GitHub reports the issue #100 pull request as merged; the merge URL and commit are recorded in Progress and handoff.
+- [x] Repository rules protect `main` and SemVer release tags without requiring a second reviewer while Pivi remains single-maintainer.
 - [ ] `PiviPlugin` becomes a lifecycle-focused composition root, feature consumers receive narrow facades, and existing behavior/configuration remain compatible under lifecycle and feature tests.
 - [ ] Cross-package imports are restricted to curated exports and architecture checks reject undeclared or internal package paths without adding another workspace.
 - [ ] Large UI/runtime factories and coordinators are split by user-facing feature only where a measured ownership seam exists; no generic DI container is introduced.
@@ -62,6 +62,8 @@ Not in scope:
 | 2026-09-04 | Integrate `check:docs-contracts` through `check:boundaries`, not a duplicate workflow step. | Shared quality gates already run `check:boundaries` in PR and release workflows. | WS-01 |
 | 2026-09-04 | Delete the stale standalone marketing draft from Git and the working tree in the P0 change. | The maintainer explicitly retired it; no tracked document referenced it, and future community work is represented by gated WS-08/WS-09 instead. | WS-01 |
 | 2026-09-04 | Treat later workstream acceptance details as provisional until each is re-inspected and linked to its own issue after the P0 merge. | The report is static review input; implementation facts can change while WS-01 is under review. | WS-02–WS-09 |
+| 2026-09-04 | Continue post-P0 work after the maintainer approved the merge, using protected-branch pull requests for repository changes. | Supersedes the earlier stop-after-PR execution limit without weakening the now-active repository rules. | WS-02–WS-09 |
+| 2026-09-04 | Do not add a Sponsor link or `.github/FUNDING.yml` until a valid funding destination exists. | `github.com/sponsors/shuuul` currently redirects to the ordinary profile; a broken funding route would be less trustworthy than an explicit blocked item. | WS-08–WS-09 |
 
 ## Workstreams
 
@@ -69,15 +71,15 @@ Use `Pending`, `Claimed`, `In progress`, `Blocked`, or `Done`.
 
 | ID | Deliverable | Owner | Status | Dependencies | Verification |
 | --- | --- | --- | --- | --- | --- |
-| WS-01 | Issue #100: remote-only MCP capability manifest, aligned active docs, obsolete smoke cleanup, contract checker, and PR | Amp | Blocked | PR #101 must pass CI and be merged by the maintainer | Focused Jest; `check:docs-contracts`; `check:boundaries`; typecheck; lint; diff check; PR CI |
-| WS-02 | Protect `main` and SemVer tags with required quality/platform checks and conversation resolution | Unassigned | Blocked | WS-01 PR merged; explicit approval before changing repository rules | Query effective GitHub rules; demonstrate force-push/delete denial and required checks without a reviewer requirement |
-| WS-03 | Reduce `PiviPlugin` to lifecycle composition and introduce responsibility-scoped application/feature facades | Unassigned | Blocked | WS-01 PR merged; fresh ownership/call-graph inspection; dedicated issue | Lifecycle tests, feature contract tests, architecture check, full quality gates |
-| WS-04 | Curate package exports and reject undeclared/internal cross-package imports | Unassigned | Blocked | WS-01 PR merged; WS-03 boundary decision where imports overlap; dedicated issue | Export contract fixtures, architecture check, typecheck, build |
+| WS-01 | Issue #100: remote-only MCP capability manifest, aligned active docs, obsolete smoke cleanup, contract checker, and PR | Amp | Done | None | Focused Jest; `check:docs-contracts`; `check:boundaries`; typecheck; lint; diff check; PR CI |
+| WS-02 | Issue #102: protect `main` and SemVer tags with required quality/platform checks and conversation resolution | Amp | Done | WS-01 done; maintainer authorized continued execution | Query effective GitHub rules; verify force-push/delete restrictions and required checks without a reviewer requirement |
+| WS-03 | Issue #103: reduce `PiviPlugin` to lifecycle composition and introduce responsibility-scoped application/feature facades | Unassigned | Pending | Fresh ownership/call-graph inspection | Lifecycle tests, feature contract tests, architecture check, full quality gates |
+| WS-04 | Issue #104: curate package exports and reject undeclared/internal cross-package imports | Unassigned | Blocked | WS-03 boundary decision where imports overlap | Export contract fixtures, architecture check, typecheck, build |
 | WS-05 | Split oversized UI/runtime factories and coordinators along verified chat/session/workspace/integration/settings use-case seams | Unassigned | Blocked | WS-01 PR merged; WS-03 application boundary settled; dedicated issue | Feature suites plus dependency-count and changed-slice evidence recorded in issue |
-| WS-06 | Add Pi compatibility manifest and one issue-updating next-version canary | Unassigned | Blocked | WS-01 PR merged; current shim inventory; dedicated issue | Manifest completeness check, `test:pi-compat`, scheduled canary dry run |
-| WS-07 | Add PR bundle delta/top-input reporting and improve warning/error test signal | Unassigned | Blocked | WS-01 PR merged; refreshed bundle baseline; dedicated issue | Metafile comparison fixture, CI summary fixture, focused noisy-console tests, bundle gate |
-| WS-08 | Enable Discussions and add contributor, conduct, support, issue-template, funding, and public roadmap entry points | Unassigned | Blocked | WS-01 PR merged; explicit approval for repository settings; community issue | Link checks, template rendering review, effective Discussions categories/settings query |
-| WS-09 | Publish three starter recipes, desktop support matrix, showcase, and monthly maintenance/funding report cadence | Unassigned | Blocked | WS-01 PR merged; WS-08 entry points; refreshed platform evidence | Recipe walkthroughs, platform smoke evidence, published links and named cadence owner |
+| WS-06 | Add Pi compatibility manifest and one issue-updating next-version canary | Unassigned | Pending | Current shim inventory and tracking-issue decision | Manifest completeness check, `test:pi-compat`, scheduled canary dry run |
+| WS-07 | Add PR bundle delta/top-input reporting and improve warning/error test signal | Unassigned | Pending | Refreshed bundle baseline and CI-summary design | Metafile comparison fixture, CI summary fixture, focused noisy-console tests, bundle gate |
+| WS-08 | Issue #105: enable Discussions and add contributor, conduct, support, issue-template, funding, and public roadmap entry points | Amp | In progress | Maintainer authorized continued execution; funding destination unavailable | Link checks, template rendering review, effective Discussions categories/settings query |
+| WS-09 | Publish three starter recipes, desktop support matrix, showcase, and monthly maintenance/funding report cadence | Amp | In progress | WS-08 repository entry points in review; funding destination unavailable | Recipe walkthroughs, platform smoke evidence, published links and named cadence owner |
 
 ## Verification
 
@@ -145,6 +147,30 @@ Append entries rather than rewriting another worker's record.
 - Blockers: WS-01 and every later workstream are blocked on PR #101 merging.
 - Next action: Maintainer reviews PR #101; no broader refactor starts before merge.
 
+### 2026-09-04 — Amp — P0 merge gate satisfied
+
+- Changed: Maintainer authorized merge after all checks passed; [PR #101](https://github.com/shuuul/obsidian-pivi/pull/101) was squash-merged into `main`, automatically closing issue #100 and deleting the remote branch.
+- Evidence: GitHub reports merge commit [`6545cc4e`](https://github.com/shuuul/obsidian-pivi/commit/6545cc4ee09f399245ee93cad74f9f91463fe0a8); `quality-gates`, macOS platform security, and Windows platform security all completed successfully.
+- Remaining: Execute the now-unblocked workstreams in dependency order.
+- Blockers: WS-04/WS-05 retain their WS-03 dependency; other workstreams require their own decision-complete implementation slices.
+- Next action: Apply and verify the repository rules in issue #102, then begin the fresh WS-03 call-graph inspection.
+
+### 2026-09-04 — Amp — Public issue backlog
+
+- Changed: Created [#102](https://github.com/shuuul/obsidian-pivi/issues/102) for repository rules, [#103](https://github.com/shuuul/obsidian-pivi/issues/103) for the lifecycle-only composition root, [#104](https://github.com/shuuul/obsidian-pivi/issues/104) for curated package exports, and [#105](https://github.com/shuuul/obsidian-pivi/issues/105) for community entry points and recipes.
+- Evidence: GitHub reports all four issues open with the report's requested titles and bounded acceptance criteria.
+- Remaining: Implement and verify each workstream; create narrower follow-up issues only when WS-06/WS-07 inventory proves they cannot remain contained workstreams.
+- Blockers: As listed in the workstream table.
+- Next action: Complete WS-02 against effective GitHub repository rules.
+
+### 2026-09-04 — Amp — Repository protection and community entry points
+
+- Changed: Enabled Discussions; applied branch ruleset [22270940](https://github.com/shuuul/obsidian-pivi/rules/22270940) and tag ruleset [22270941](https://github.com/shuuul/obsidian-pivi/rules/22270941); closed issue #102 with effective-rule evidence; drafted contribution, conduct, support, issue-form, platform-support, reporting-template, and three starter-recipe files; created newcomer-sized recipe issues [#106](https://github.com/shuuul/obsidian-pivi/issues/106) and [#107](https://github.com/shuuul/obsidian-pivi/issues/107) with the `good first issue` label.
+- Evidence: Effective `main` rules require strict quality/macOS/Windows checks and conversation resolution, require a pull request with zero approvals, and block deletion/non-fast-forward updates; SemVer tags block updates and deletion. GitHub exposes Announcements, Q&A, Show and tell, and Ideas Discussion categories.
+- Remaining: Validate and merge the repository community files; inspect rendered issue forms after merge. Add `.github/FUNDING.yml` only after a valid funding destination exists; `https://github.com/sponsors/shuuul` currently redirects to the ordinary profile and is not a usable destination.
+- Blockers: Funding and Sponsor links are blocked on the maintainer configuring a valid destination. Publication of recurring Discussion updates remains a maintainer-owned cadence rather than repository code.
+- Next action: Open the WS-08 repository changes as a protected-branch pull request, then make WS-03 decision-complete on a separate branch.
+
 ## Completion summary
 
-Pending. This spec remains Active after the WS-01 PR opens; opening or passing CI does not authorize archival or unblock broader refactoring.
+Pending. The WS-01 merge gate is satisfied. This spec remains Active until the remaining workstreams are either completed with evidence or explicitly deferred with an owner and reason.

--- a/specs/049-post-review-contracts-architecture-and-community-execution.md
+++ b/specs/049-post-review-contracts-architecture-and-community-execution.md
@@ -29,7 +29,7 @@ Preserve Pivi's existing package architecture while making active documentation 
 - [ ] Large UI/runtime factories and coordinators are split by user-facing feature only where a measured ownership seam exists; no generic DI container is introduced.
 - [ ] Every Pivi-owned Pi compatibility shim records its upstream version, reason, verification test, removal condition, and tracking issue, with one non-duplicating canary route.
 - [ ] Pull requests report explainable bundle change data and focused test suites fail on unexpected warning/error noise without replacing correctness assertions with global coverage targets.
-- [ ] Public contribution, discussion, recipe, platform-support, and funding paths exist and have named recurring owners/cadences before the spec closes.
+- [ ] Public contribution, discussion, recipe, and platform-support paths exist; optional update templates are available without creating an unsupported publication or funding commitment.
 
 ## Scope and non-goals
 
@@ -39,7 +39,7 @@ In scope:
 - GitHub branch/tag protection and community entry points after the P0 merge gate.
 - Bounded composition-root, feature-facade, export-surface, and vertical-factory improvements after re-inspection.
 - Pi compatibility lifecycle, bundle-delta reporting, and test-signal improvements.
-- Starter recipes, desktop support tiers, and transparent maintenance/funding reporting.
+- Starter recipes, desktop support tiers, and optional transparent maintenance/support reporting templates.
 
 Not in scope:
 
@@ -63,7 +63,7 @@ Not in scope:
 | 2026-09-04 | Delete the stale standalone marketing draft from Git and the working tree in the P0 change. | The maintainer explicitly retired it; no tracked document referenced it, and future community work is represented by gated WS-08/WS-09 instead. | WS-01 |
 | 2026-09-04 | Treat later workstream acceptance details as provisional until each is re-inspected and linked to its own issue after the P0 merge. | The report is static review input; implementation facts can change while WS-01 is under review. | WS-02–WS-09 |
 | 2026-09-04 | Continue post-P0 work after the maintainer approved the merge, using protected-branch pull requests for repository changes. | Supersedes the earlier stop-after-PR execution limit without weakening the now-active repository rules. | WS-02–WS-09 |
-| 2026-09-04 | Do not add a Sponsor link or `.github/FUNDING.yml` until a valid funding destination exists. | `github.com/sponsors/shuuul` currently redirects to the ordinary profile; a broken funding route would be less trustworthy than an explicit blocked item. | WS-08–WS-09 |
+| 2026-09-04 | Do not add a Sponsor link or `.github/FUNDING.yml`, and do not make a recurring publication cadence a completion requirement. | The maintainer is not applying for GitHub Sponsors now and prefers optional update templates over a schedule that may not be sustained. Funding can return as independent work after a valid destination exists. | WS-08–WS-09 |
 
 ## Workstreams
 
@@ -78,8 +78,8 @@ Use `Pending`, `Claimed`, `In progress`, `Blocked`, or `Done`.
 | WS-05 | Split oversized UI/runtime factories and coordinators along verified chat/session/workspace/integration/settings use-case seams | Unassigned | Blocked | WS-01 PR merged; WS-03 application boundary settled; dedicated issue | Feature suites plus dependency-count and changed-slice evidence recorded in issue |
 | WS-06 | Add Pi compatibility manifest and one issue-updating next-version canary | Unassigned | Pending | Current shim inventory and tracking-issue decision | Manifest completeness check, `test:pi-compat`, scheduled canary dry run |
 | WS-07 | Add PR bundle delta/top-input reporting and improve warning/error test signal | Unassigned | Pending | Refreshed bundle baseline and CI-summary design | Metafile comparison fixture, CI summary fixture, focused noisy-console tests, bundle gate |
-| WS-08 | Issue #105: enable Discussions and add contributor, conduct, support, issue-template, funding, and public roadmap entry points | Amp | In progress | Maintainer authorized continued execution; funding destination unavailable | Link checks, template rendering review, effective Discussions categories/settings query |
-| WS-09 | Publish three starter recipes, desktop support matrix, showcase, and monthly maintenance/funding report cadence | Amp | In progress | WS-08 repository entry points in review; funding destination unavailable | Recipe walkthroughs, platform smoke evidence, published links and named cadence owner |
+| WS-08 | Issue #105: enable Discussions and add contributor, conduct, support, and issue-template entry points | Amp | In progress | Maintainer authorized continued execution | Link checks, template rendering review, effective Discussions categories/settings query |
+| WS-09 | Publish three starter recipes, desktop support matrix, showcase route, and optional update/report templates | Amp | In progress | WS-08 repository entry points in review | Recipe walkthroughs, platform evidence, published links, and template review |
 
 ## Verification
 
@@ -167,9 +167,17 @@ Append entries rather than rewriting another worker's record.
 
 - Changed: Enabled Discussions; applied branch ruleset [22270940](https://github.com/shuuul/obsidian-pivi/rules/22270940) and tag ruleset [22270941](https://github.com/shuuul/obsidian-pivi/rules/22270941); closed issue #102 with effective-rule evidence; drafted contribution, conduct, support, issue-form, platform-support, reporting-template, and three starter-recipe files; created newcomer-sized recipe issues [#106](https://github.com/shuuul/obsidian-pivi/issues/106) and [#107](https://github.com/shuuul/obsidian-pivi/issues/107) with the `good first issue` label.
 - Evidence: Effective `main` rules require strict quality/macOS/Windows checks and conversation resolution, require a pull request with zero approvals, and block deletion/non-fast-forward updates; SemVer tags block updates and deletion. GitHub exposes Announcements, Q&A, Show and tell, and Ideas Discussion categories.
-- Remaining: Validate and merge the repository community files; inspect rendered issue forms after merge. Add `.github/FUNDING.yml` only after a valid funding destination exists; `https://github.com/sponsors/shuuul` currently redirects to the ordinary profile and is not a usable destination.
-- Blockers: Funding and Sponsor links are blocked on the maintainer configuring a valid destination. Publication of recurring Discussion updates remains a maintainer-owned cadence rather than repository code.
-- Next action: Open the WS-08 repository changes as a protected-branch pull request, then make WS-03 decision-complete on a separate branch.
+- Remaining: Merge the repository community files and inspect the default-branch community profile and rendered issue forms.
+- Blockers: None. Funding and a recurring Discussion cadence were explicitly removed from this spec's completion criteria; the templates remain optional.
+- Next action: Merge the green community pull request, verify GitHub's effective surfaces, and record completion evidence.
+
+### 2026-09-04 — Maintainer decisions for WS-08/WS-09 closeout
+
+- Changed: The maintainer authorized merging [PR #108](https://github.com/shuuul/obsidian-pivi/pull/108), chose to keep weekly/monthly templates without committing to a publication cadence, and chose not to apply for GitHub Sponsors now.
+- Evidence: GitHub Sponsors setup would require a supported region, 2FA, payout/tax onboarding, profile and tiers, and approval; no valid `shuuul` Sponsors profile currently exists. PR #108 remains mergeable with all three required checks successful.
+- Remaining: Merge PR #108 and validate the resulting default-branch contribution and issue surfaces.
+- Blockers: None.
+- Next action: Push this decision sync to PR #108, wait for its required checks, then merge it.
 
 ## Completion summary
 


### PR DESCRIPTION
## Summary

- add contribution, conduct, support, and structured issue entry points
- publish three review-first starter recipes and a desktop platform support matrix
- add weekly and monthly public update templates and record post-review execution evidence in spec 049

Discussions are enabled. Issues #106 and #107 provide two bounded `good first issue` recipe contributions.

A funding destination is intentionally not linked yet: `github.com/sponsors/shuuul` does not currently resolve to a Sponsor profile.

Advances #105.

## Validation

- `npm run check:boundaries`
- `npm run lint`
- commit hook: `npm run typecheck`, `npm run lint`, `npm run check:architecture`
- issue-form YAML parse
- local Markdown link check (10 files)
- `git diff --check`