### PR TITLE
docs: archive completed spec 049

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -10,7 +10,6 @@ Copy [000-template.md](000-template.md) to start a spec.
 
 | Spec | Created | Outcome |
 |---|---|---|
-| [049 — Post-review contracts architecture and community execution](049-post-review-contracts-architecture-and-community-execution.md) | Active | P0-gated execution of documentation contracts, bounded architecture improvements, compatibility maintenance, and community entry points. |
 
 ## Archived specs
 
@@ -64,6 +63,7 @@ Copy [000-template.md](000-template.md) to start a spec.
 | [046-composable-obsidian-workflow-prompts.md](archive/046-composable-obsidian-workflow-prompts.md) | 2026-09-03 | Modular system-prompt registry, Settings Prompt tab, failure-driven guidance, and main-Agent `pivi_prompt` management. |
 | [047-provider-anchored-context-accounting.md](archive/047-provider-anchored-context-accounting.md) | 2026-09-03 | Provider-anchored context pressure with bounded trailing estimates and calibration, truthful compaction timeout/retry semantics, and a fixed read ceiling (issues #98, #99). |
 | [048 — Settings UI system and Obsidian-native page navigation](archive/048-settings-ui-system-and-grouped-navigation.md) | 2026-09-03 | Delivered one enforced settings primitive/CSS system with Obsidian 1.13 native grouped navigation, indexed search routing, and all settings pages migrated. |
+| [049 — Post-review contracts architecture and community execution](archive/049-post-review-contracts-architecture-and-community-execution.md) | 2026-09-04 | Aligned active MCP docs, protected repository boundaries, reduced composition/API friction, added compatibility and quality signals, and launched community and funding routes. |
 
 ## Numbering and files
 

--- a/specs/archive/049-post-review-contracts-architecture-and-community-execution.md
+++ b/specs/archive/049-post-review-contracts-architecture-and-community-execution.md
@@ -1,7 +1,7 @@
 ---
 id: "049"
 title: "Post-review contracts architecture and community execution"
-status: Active
+status: Completed
 created: 2026-09-04
 updated: 2026-09-04
 coordinator: "Amp"
@@ -250,6 +250,14 @@ Append entries rather than rewriting another worker's record.
 - Blockers: Final archival still depends on PRs #109, #110, #112, #114, and #116 landing.
 - Next action: Validate the funding configuration and documentation, commit the update to PR #116, and rerun its required checks.
 
+### 2026-09-04 — Amp — Final default-branch acceptance
+
+- Changed: Merged [PR #109](https://github.com/shuuul/obsidian-pivi/pull/109), [PR #110](https://github.com/shuuul/obsidian-pivi/pull/110), [PR #112](https://github.com/shuuul/obsidian-pivi/pull/112), [PR #114](https://github.com/shuuul/obsidian-pivi/pull/114), and [PR #116](https://github.com/shuuul/obsidian-pivi/pull/116) in dependency order. Issues #103, #104, #111, #113, and #115 closed through their owning merges.
+- Evidence: Final `main` commit [`f916eca6`](https://github.com/shuuul/obsidian-pivi/commit/f916eca6de79982be8d02b5cb08205454f8420e7) passed [quality, macOS, and Windows checks](https://github.com/shuuul/obsidian-pivi/actions/runs/33892310967). The default branch serves `.github/FUNDING.yml` with `patreon: shuuul` and the Afdian URL, and its SUPPORT page records the US$3/month Patreon contract without paid-priority promises.
+- Remaining: Archive this completed spec and merge the archival-only change.
+- Blockers: None.
+- Next action: Run the spec validator, archive spec 049, and submit the archival-only pull request.
+
 ## Completion summary
 
-All nine implementation workstreams are complete. PR #108 and the P0 contract are on `main`; the architecture, exports, factory, compatibility, quality-signal, and funding-route changes remain in the protected stacked PRs. Archive only after those changes land and final default-branch checks pass.
+Completed all nine workstreams without a rewrite, new workspace, or general DI container. Active documentation now enforces the remote-only MCP contract; repository rules protect `main` and release tags; the plugin shell delegates to responsibility-scoped application facades; package exports are explicit; chat and settings UI factories have separate ownership; Pi compatibility entries have lifecycle metadata and one canary; bundle/test regressions produce actionable signals; and contribution, recipe, platform-support, Discussion, Patreon, and Afdian routes are live. All owning pull requests are merged, their issues are closed, and the final default-branch quality and platform checks passed.


### PR DESCRIPTION
## Summary

- record final default-branch acceptance evidence for spec 049
- move the completed spec into the archive
- update the specs index with the completed outcome

## Verification

- `npm run check:specs`
- `npm run check:docs-contracts`
- `git diff --check`
- final main CI: https://github.com/shuuul/obsidian-pivi/actions/runs/33892310967

The full local ESLint process exhausted Node heap at both 4 GiB and 12 GiB while committing this docs-only move. The same source tree passed full lint in the linked main CI; Markdown under `specs/` has no matching ESLint configuration.