### PR TITLE
fix(ci): bind release publishing to repository

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -157,6 +157,7 @@ jobs:
 
       - name: Create or update GitHub release
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           IS_PRERELEASE: ${{ needs.build.outputs.is-prerelease }}
           RELEASE_NOTES_FILE: release-bundle/release-notes.md

--- a/tests/unit/scripts/releaseWorkflow.test.ts
+++ b/tests/unit/scripts/releaseWorkflow.test.ts
@@ -88,6 +88,7 @@ describe('release provenance workflow', () => {
     expect(workflow).toMatch(/build:[\s\S]*?permissions:\s*\n\s+contents: read/);
     expect(workflow).toMatch(/publish:[\s\S]*?permissions:\s*\n\s+contents: write/);
     expect(workflow).toContain('persist-credentials: false');
+    expect(workflow).toContain('GH_REPO: ${{ github.repository }}');
   });
 
   it('keeps every CI checkout read-only without persisted credentials', () => {


### PR DESCRIPTION
## Summary

- set `GH_REPO` explicitly in the checkout-free release publishing job
- lock the repository-binding requirement with a workflow regression test

## Root cause

The least-privilege job split intentionally removed checkout from the write-capable `publish` job. Without a checkout or explicit repository, `gh release` tried to infer the repository from `.git` and failed before creating 0.28.0.

## Verification

- `npm run test -- --runInBand tests/unit/scripts/releaseWorkflow.test.ts`
- pre-commit: typecheck, lint, architecture boundaries
- 0.28.0 was published from the successful tag-build artifact and all three published assets matched byte-for-byte
